### PR TITLE
[MCC-403926] Replace getForKeyCaseInsensitive for getForKey

### DIFF
--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/HttpVerbOps.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/HttpVerbOps.scala
@@ -19,5 +19,6 @@ object HttpVerbOps {
     * @param method The String value of the HTTP verb
     * @return Akka HttpMethod
     */
-  implicit def httpVerb(method: String): HttpMethod = HttpMethods.getForKeyCaseInsensitive(method).getOrElse(HttpMethods.GET)
+  implicit def httpVerb(method: String): HttpMethod = HttpMethods.getForKey(method).getOrElse(HttpMethods.GET)
+
 }

--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
@@ -1,0 +1,34 @@
+package com.mdsol.mauth.http
+
+import java.net.URI
+
+import com.mdsol.mauth.http.Implicits._
+import com.mdsol.mauth.{SignedRequest, UnsignedRequest}
+import org.scalatest.{Matchers, WordSpec}
+
+class ImplicitsTest extends WordSpec with Matchers {
+
+  "Implicits fromSignedRequestToHttpRequest" should {
+
+    "Generate a POST HttpRequest from a SignedRequest" in {
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "POST", uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(POST)")
+    }
+
+    "Generate a GET HttpRequest from a SignedRequest when non-uppercase method specified" in {
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "post", uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
+    }
+
+    "Generate a GET HttpRequest from a SignedRequest when http method does not exist" in {
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "INVENTED", uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
+    }
+
+    "Generate a GET HttpRequest from a SignedRequest if not http method specified" in {
+      val signedRequest = SignedRequest(UnsignedRequest(uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
+    }
+  }
+
+}

--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
@@ -11,22 +11,22 @@ class ImplicitsTest extends WordSpec with Matchers {
   "Implicits fromSignedRequestToHttpRequest" should {
 
     "Generate a POST HttpRequest from a SignedRequest" in {
-      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "POST", uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "POST", uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(POST)")
     }
 
     "Generate a GET HttpRequest from a SignedRequest when non-uppercase method specified" in {
-      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "post", uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "post", uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
     }
 
     "Generate a GET HttpRequest from a SignedRequest when http method does not exist" in {
-      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "INVENTED", uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "INVENTED", uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
     }
 
     "Generate a GET HttpRequest from a SignedRequest if not http method specified" in {
-      val signedRequest = SignedRequest(UnsignedRequest(uri = new URI("/")), "X_MWS_AUTHENTICATION_HEADER_VALUE", "X_MWS_TIME_HEADER_VALUE")
+      val signedRequest = SignedRequest(UnsignedRequest(uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
     }
   }


### PR DESCRIPTION
Fix an issue when using the implicit method "fromSignedRequestToHttpRequest" which is ignoring Https methods other than GET because the method akka.http.scaladsl.model.HttpMethods.getForKeyCaseInsensitive("POST") is returning None. 

This method has been replaced for akka.http.scaladsl.model.HttpMethods.getForKey("POST") which returns the "HttpMethod(POST)" value correctly.