### PR TITLE
[MCC-403926] Enforce always content type application/json

### DIFF
--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/Implicits.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/Implicits.scala
@@ -1,7 +1,7 @@
 package com.mdsol.mauth.http
 
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpHeader, HttpRequest, Uri}
+import akka.http.scaladsl.model._
 import com.mdsol.mauth.SignedRequest
 import com.mdsol.mauth.http.HttpVerbOps._
 
@@ -15,7 +15,7 @@ object Implicits {
       case Some(s: String) => s
     }
 
-    HttpRequest(sr.req.httpMethod, uri = Uri(sr.req.uri.toString), entity = entityBody)
+    HttpRequest(sr.req.httpMethod, uri = Uri(sr.req.uri.toString), entity = HttpEntity(ContentTypes.`application/json`, entityBody))
       .withHeaders(mapToHeaderSequence(sr.req.headers) ++: scala.collection.immutable.Seq(
         `X-MWS-Authentication`(sr.authHeader),
         `X-MWS-Time`(sr.timeHeader)))

--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
@@ -2,6 +2,8 @@ package com.mdsol.mauth.http
 
 import java.net.URI
 
+import akka.http.scaladsl.model.{ContentType, HttpEntity, MediaType, MediaTypes}
+import com.google.common.net.HttpHeaders
 import com.mdsol.mauth.http.Implicits._
 import com.mdsol.mauth.{SignedRequest, UnsignedRequest}
 import org.scalatest.{Matchers, WordSpec}
@@ -28,6 +30,12 @@ class ImplicitsTest extends WordSpec with Matchers {
     "Generate a GET HttpRequest from a SignedRequest if not http method specified" in {
       val signedRequest = SignedRequest(UnsignedRequest(uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
+    }
+
+    "Generate a POST HttpRequest should created a entity with the application/json content type" in {
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "POST", uri = new URI("/"),
+        headers = Map(HttpHeaders.CONTENT_TYPE -> MediaTypes.`application/json`.value)), "", "")
+      fromSignedRequestToHttpRequest(signedRequest).entity.contentType should be(ContentType(MediaTypes.`application/json`))
     }
   }
 


### PR DESCRIPTION
Fix POST/PATCH so instead of sending always Content Type "plain/text", enforce that Content-type  been "application/json".