### PR TITLE
MCC-410498 encoding changed from UTF-8 to ISO-8859-1

### DIFF
--- a/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
+++ b/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
@@ -70,11 +70,11 @@ public class RequestAuthenticator implements Authenticator {
     String unencryptedRequestString =
         MAuthSignatureHelper.generateUnencryptedSignature(
             mAuthRequest.getAppUUID(), mAuthRequest.getHttpMethod(), mAuthRequest.getResourcePath(),
-            new String(mAuthRequest.getMessagePayload(), StandardCharsets.UTF_8),
+            new String(mAuthRequest.getMessagePayload(), StandardCharsets.ISO_8859_1),
             String.valueOf(mAuthRequest.getRequestTime())
         );
     byte[] messageDigest_bytes = MAuthSignatureHelper
-        .getHexEncodedDigestedString(unencryptedRequestString).getBytes(StandardCharsets.UTF_8);
+        .getHexEncodedDigestedString(unencryptedRequestString).getBytes(StandardCharsets.ISO_8859_1);
 
     // Compare the decrypted signature and the recreated signature hashes.
     // If both match, the request was signed by the requesting application and is valid.

--- a/modules/mauth-authenticator/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
+++ b/modules/mauth-authenticator/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
@@ -47,10 +47,10 @@ class RequestAuthenticator(publicKeyProvider: ClientPublicKeyProvider, epochTime
                 mAuthRequest.getAppUUID,
                 mAuthRequest.getHttpMethod,
                 mAuthRequest.getResourcePath,
-                new String(mAuthRequest.getMessagePayload, StandardCharsets.UTF_8),
+                new String(mAuthRequest.getMessagePayload, StandardCharsets.ISO_8859_1),
                 String.valueOf(mAuthRequest.getRequestTime)
               )
-            val messageDigest_bytes = MAuthSignatureHelper.getHexEncodedDigestedString(unencryptedRequestString).getBytes(StandardCharsets.UTF_8)
+            val messageDigest_bytes = MAuthSignatureHelper.getHexEncodedDigestedString(unencryptedRequestString).getBytes(StandardCharsets.ISO_8859_1)
 
             // Compare the decrypted signature and the recreated signature hashes.
             // If both match, the request was signed by the requesting application and is valid.

--- a/modules/mauth-authenticator/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
+++ b/modules/mauth-authenticator/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
@@ -39,7 +39,7 @@ trait RequestAuthenticatorBaseSpec extends FlatSpec with BeforeAndAfterAll with 
   val CLIENT_UNICODE_REQUEST_AUTHENTICATION_HEADER: String = "MWS " + EXISTING_CLIENT_APP_UUID.toString + ":" + CLIENT_UNICODE_REQUEST_SIGNATURE
   val CLIENT_UNICODE_REQUEST_METHOD: String = HttpPost.METHOD_NAME
   val CLIENT_UNICODE_REQUEST_PATH = "/resource/path"
-  val CLIENT_UNICODE_REQUEST_BODY = "Message with some Unicode characters inside: ș吉ń艾ęتあù"
+  val CLIENT_UNICODE_REQUEST_BODY = "Message with some Unicode characters inside: È™å�‰Å„è‰¾Ä™Øªã�‚Ã¹"
   val CLIENT_NO_BODY_REQUEST_SIGNATURE: String =
     """NddGBdXnB3/ne3oCmYJQ20mASPHifsI0sG3mt034jjRfjlTafOYJ/kt3RJYk
       |OMLT104GtzTgFfQBeTSJpOrBK/+EK9T0V+JNmjrU6Y9FpcH4p3hB2liooKjH
@@ -62,7 +62,7 @@ trait RequestAuthenticatorBaseSpec extends FlatSpec with BeforeAndAfterAll with 
       .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_HEADER)
       .withTimeHeaderValue(CLIENT_X_MWS_TIME_HEADER_VALUE)
       .withHttpMethod(CLIENT_REQUEST_METHOD)
-      .withMessagePayload(CLIENT_REQUEST_BODY.getBytes(StandardCharsets.UTF_8))
+      .withMessagePayload(CLIENT_REQUEST_BODY.getBytes(StandardCharsets.ISO_8859_1))
       .withResourcePath(CLIENT_REQUEST_PATH)
       .build
   }
@@ -73,7 +73,7 @@ trait RequestAuthenticatorBaseSpec extends FlatSpec with BeforeAndAfterAll with 
       .withTimeHeaderValue(CLIENT_X_MWS_TIME_HEADER_VALUE)
       .withHttpMethod(CLIENT_REQUEST_METHOD)
       .withMessagePayload((CLIENT_REQUEST_BODY + " this makes this request invalid.")
-        .getBytes(StandardCharsets.UTF_8))
+        .getBytes(StandardCharsets.ISO_8859_1))
       .withResourcePath(CLIENT_REQUEST_PATH)
       .build
   }
@@ -83,7 +83,7 @@ trait RequestAuthenticatorBaseSpec extends FlatSpec with BeforeAndAfterAll with 
       .withAuthenticationHeaderValue(CLIENT_UNICODE_REQUEST_AUTHENTICATION_HEADER)
       .withTimeHeaderValue(CLIENT_UNICODE_X_MWS_TIME_HEADER_VALUE)
       .withHttpMethod(CLIENT_UNICODE_REQUEST_METHOD)
-      .withMessagePayload(CLIENT_UNICODE_REQUEST_BODY.getBytes(StandardCharsets.UTF_8))
+      .withMessagePayload(CLIENT_UNICODE_REQUEST_BODY.getBytes(StandardCharsets.ISO_8859_1))
       .withResourcePath(CLIENT_UNICODE_REQUEST_PATH)
       .build
   }


### PR DESCRIPTION
Changed encoding from UTF-8 to ISO-8859-1 to support upload of binary files and not just JSON strings in the request.