### PR TITLE
MCC-398155 Update bouncy castle and sync the snapshot version in develop with the version in master.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies extends DependencyUtils {
   val akkaHttp: ModuleID = "com.typesafe.akka" %% "akka-http" % Version.akkaHttp
   val akkaStream: ModuleID = "com.typesafe.akka" %% "akka-stream" % "2.5.13"
   val apacheHttpClient: ModuleID = "org.apache.httpcomponents" % "httpclient" % "4.5.5"
-  val bouncyCastlePkix: ModuleID = "org.bouncycastle" % "bcpkix-jdk15on" % "1.59"
+  val bouncyCastlePkix: ModuleID = "org.bouncycastle" % "bcpkix-jdk15on" % "1.60"
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.11"
   val commonsLang3: ModuleID = "org.apache.commons" % "commons-lang3" % "3.7"
   val guava: ModuleID = "com.google.guava" % "guava" % "23.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.2-SNAPSHOT"
+version in ThisBuild := "1.0.5-SNAPSHOT"


### PR DESCRIPTION
As the title says, the goal is to update bouncy castle and sync the snapshot version in develop with the version in master.

Right after this, there will be a PR to merge `develop` into `master` which I expect will do a release of version `1.0.5` into https://repo1.maven.org/maven2/com/mdsol/ for the modules of this repo.

IF someone feels we should really fix `master` with a PR to downgrade the version there to 1.0.2-SNAPSHOT and then publish `1.0.2` that is another way to go.

Here is the relevant Jira ticket https://jira.mdsol.com/browse/MCC-398155