### PR TITLE
[MCC-414889] Fix - Add support to customize Content-Type

### DIFF
--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
   * @param uri        The URI of the API call , (host name and port not included)
   * @param body       The body of the request in string form
   */
-case class UnsignedRequest(httpMethod: String = "GET", uri: URI, body: Option[String] = None, headers: Map[String, String] = Map.empty)
+case class UnsignedRequest(httpMethod: String = "GET", uri: URI, body: Option[String] = None, headers: Map[String, String] = Map.empty, contentType: Option[String] = None)
 
 /**
   * Library agnostic representation of a signed request, including header data

--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
   * @param uri        The URI of the API call , (host name and port not included)
   * @param body       The body of the request in string form
   */
-case class UnsignedRequest(httpMethod: String = "GET", uri: URI, body: Option[String] = None, headers: Map[String, String] = Map.empty, contentType: Option[String] = None)
+case class UnsignedRequest(httpMethod: String = "GET", uri: URI, body: Option[String] = None, headers: Map[String, String] = Map.empty)
 
 /**
   * Library agnostic representation of a signed request, including header data

--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/HttpVerbOps.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/HttpVerbOps.scala
@@ -19,6 +19,6 @@ object HttpVerbOps {
     * @param method The String value of the HTTP verb
     * @return Akka HttpMethod
     */
-  implicit def httpVerb(method: String): HttpMethod = HttpMethods.getForKey(method).getOrElse(HttpMethods.GET)
+  implicit def httpVerb(method: String): HttpMethod = HttpMethods.getForKey(method.toUpperCase).getOrElse(HttpMethods.GET)
 
 }

--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
@@ -2,8 +2,7 @@ package com.mdsol.mauth.http
 
 import java.net.URI
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity, MediaType, MediaTypes}
-import com.google.common.net.HttpHeaders
+import akka.http.scaladsl.model._
 import com.mdsol.mauth.http.Implicits._
 import com.mdsol.mauth.{SignedRequest, UnsignedRequest}
 import org.scalatest.{Matchers, WordSpec}
@@ -12,13 +11,18 @@ class ImplicitsTest extends WordSpec with Matchers {
 
   "Implicits fromSignedRequestToHttpRequest" should {
 
-    "Generate a POST HttpRequest from a SignedRequest" in {
+    "Generate a POST HttpRequest from a SignedRequest when POST method specified" in {
       val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "POST", uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(POST)")
     }
 
-    "Generate a GET HttpRequest from a SignedRequest when non-uppercase method specified" in {
+    "Generate a POST HttpRequest from a SignedRequest when lowercase POST method specified" in {
       val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "post", uri = new URI("/")), "", "")
+      fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(POST)")
+    }
+
+    "Generate a GET HttpRequest from a SignedRequest when GET method specified" in {
+      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "get", uri = new URI("/")), "", "")
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
     }
 
@@ -32,10 +36,40 @@ class ImplicitsTest extends WordSpec with Matchers {
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
     }
 
-    "Generate a POST HttpRequest should created a entity with the application/json content type" in {
-      val signedRequest = SignedRequest(UnsignedRequest(httpMethod = "POST", uri = new URI("/"),
-        headers = Map(HttpHeaders.CONTENT_TYPE -> MediaTypes.`application/json`.value)), "", "")
-      fromSignedRequestToHttpRequest(signedRequest).entity.contentType should be(ContentType(MediaTypes.`application/json`))
+    "Generate a POST HttpRequest should created an entity with the application/json content type" in {
+      val signedRequest = SignedRequest(
+        UnsignedRequest(httpMethod = "POST", uri = new URI("/"), headers = Map.empty, body = Some("Request body"),
+          contentType = Some(ContentTypes.`application/json`.toString())),
+        "", "")
+
+      val entity = fromSignedRequestToHttpRequest(signedRequest).entity
+      fromSignedRequestToHttpRequest(signedRequest).entity should be(
+        HttpEntity(ContentTypes.`application/json`, "Request body"))
+    }
+
+    "Generate a POST HttpRequest should created an entity with plain/text when no content type specified" in {
+      val signedRequest = SignedRequest(
+        UnsignedRequest(httpMethod = "POST", uri = new URI("/"), headers = Map.empty, body = Some("")),
+        "", "")
+      fromSignedRequestToHttpRequest(signedRequest).entity.contentType should be(ContentTypes.`text/plain(UTF-8)`)
+    }
+
+    "Generate a POST HttpRequest should created an entity with plain/text when unknown content type specified" in {
+      val signedRequest = SignedRequest(
+        UnsignedRequest(httpMethod = "POST", uri = new URI("/"),
+          headers = Map.empty, body = Some(""), contentType = Some("CUSTOMIZED CONTENT TYPE")),
+        "", "")
+      fromSignedRequestToHttpRequest(signedRequest).entity.contentType should be(ContentTypes.`text/plain(UTF-8)`)
+    }
+
+    "Generate a POST HttpRequest should created a entity with the binary content type" in {
+      val signedRequest = SignedRequest(
+        UnsignedRequest(httpMethod = "POST", uri = new URI("/"),
+          headers = Map.empty, body = Some("Request body"),
+          contentType = Some(ContentTypes.`application/octet-stream`.toString())),
+        "", "")
+      fromSignedRequestToHttpRequest(signedRequest).entity should be(
+        HttpEntity(ContentTypes.`application/octet-stream`, "Request body".getBytes))
     }
   }
 

--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
@@ -3,6 +3,7 @@ package com.mdsol.mauth.http
 import java.net.URI
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
 import com.mdsol.mauth.http.Implicits._
 import com.mdsol.mauth.{SignedRequest, UnsignedRequest}
 import org.scalatest.{Matchers, WordSpec}
@@ -36,15 +37,21 @@ class ImplicitsTest extends WordSpec with Matchers {
       fromSignedRequestToHttpRequest(signedRequest).method.toString() should be("HttpMethod(GET)")
     }
 
-    "Generate a POST HttpRequest should created an entity with the application/json content type" in {
-      val signedRequest = SignedRequest(
-        UnsignedRequest(httpMethod = "POST", uri = new URI("/"), headers = Map.empty, body = Some("Request body"),
-          contentType = Some(ContentTypes.`application/json`.toString())),
-        "", "")
+    "Generate a POST HttpRequest should created an entity with the application/json content type" +
+      " and remove content type from headers" in {
 
-      val entity = fromSignedRequestToHttpRequest(signedRequest).entity
-      fromSignedRequestToHttpRequest(signedRequest).entity should be(
-        HttpEntity(ContentTypes.`application/json`, "Request body"))
+      val headers = Map("Content-Type" -> ContentTypes.`application/json`.toString(),
+        "custom_header" -> "custom_value")
+      val signedRequest = SignedRequest(
+        UnsignedRequest(httpMethod = "POST", uri = new URI("/"), headers = headers, body = Some("Request body")),
+        "x-mws-authentication-value", "x-mws-time-value")
+
+      val request = fromSignedRequestToHttpRequest(signedRequest)
+      request.entity should be(HttpEntity(ContentTypes.`application/json`, "Request body"))
+      request.headers.toString() should be(List(
+        RawHeader("custom_header", "custom_value"),
+        RawHeader("x-mws-authentication", "x-mws-authentication-value"),
+        RawHeader("x-mws-time","x-mws-time-value")).toString())
     }
 
     "Generate a POST HttpRequest should created an entity with plain/text when no content type specified" in {
@@ -55,18 +62,21 @@ class ImplicitsTest extends WordSpec with Matchers {
     }
 
     "Generate a POST HttpRequest should created an entity with plain/text when unknown content type specified" in {
+
+      val headers = Map("Content-Type" -> "CUSTOMIZED CONTENT TYPE")
+
       val signedRequest = SignedRequest(
-        UnsignedRequest(httpMethod = "POST", uri = new URI("/"),
-          headers = Map.empty, body = Some(""), contentType = Some("CUSTOMIZED CONTENT TYPE")),
+        UnsignedRequest(httpMethod = "POST", uri = new URI("/"), headers = headers, body = Some("")),
         "", "")
       fromSignedRequestToHttpRequest(signedRequest).entity.contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
 
     "Generate a POST HttpRequest should created a entity with the binary content type" in {
+
+      val headers = Map("Content-Type" -> ContentTypes.`application/octet-stream`.toString())
       val signedRequest = SignedRequest(
         UnsignedRequest(httpMethod = "POST", uri = new URI("/"),
-          headers = Map.empty, body = Some("Request body"),
-          contentType = Some(ContentTypes.`application/octet-stream`.toString())),
+          headers = headers, body = Some("Request body")),
         "", "")
       fromSignedRequestToHttpRequest(signedRequest).entity should be(
         HttpEntity(ContentTypes.`application/octet-stream`, "Request body".getBytes))


### PR DESCRIPTION
#### What is this PR for?

The following fixes have been carried out in Scala asynchronous Mauth client:
- Modify HTTP method to make it case-insensitive.
- Add support to customize content-type (apply "text/plain(UTF-8)" by default)

#### What are the relevant JIRA tickets?
[MCC-414889](https://jira.mdsol.com/browse/MCC-414889)
