### PR TITLE
[MCC-414889] Simplify method to extract content-type from headers

### DIFF
--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/Implicits.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/http/Implicits.scala
@@ -35,8 +35,7 @@ object Implicits {
     headers.map { case (k, v) => RawHeader(k, v) }.toSeq
 
   private def extractContentTypeFromHeaders(requestHeaders: Map[String, String]): Option[String] = {
-    requestHeaders.keySet.filter(_ == headers.`Content-Type`.name).
-      map(contentType => requestHeaders(contentType)).headOption
+    requestHeaders.get(headers.`Content-Type`.name)
   }
 
   private def removeContentTypeFromHeaders(requestHeaders: Map[String, String]): Map[String, String] = {


### PR DESCRIPTION
Address @red-benabas suggestion to simplify the extractContentTypeFromHeaders method using the map lookup method.