### PR TITLE
[MCC-530719] Fix to customize content-type in mAuthV2

### DIFF
--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/http/ImplicitsTest.scala
@@ -135,20 +135,14 @@ class ImplicitsTest extends AnyWordSpec with Matchers {
           RawHeader(MAuthRequest.MCC_TIME_HEADER_NAME, "mcc-time-value"),
           RawHeader(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME, "mcc-authentication-value"),
           RawHeader(MAuthRequest.X_MWS_TIME_HEADER_NAME, "x-mws-time-value"),
-          RawHeader(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, "x-mws-authentication-value"),
-          RawHeader("Content-Type", "application/json")
+          RawHeader(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, "x-mws-authentication-value")
         ).toString()
       )
     }
 
-    /* Failed as
-    Expected :text/plain; charset=UTF-8,
-    Actual   :application/octet-stream
-
-   "Generate a POST HttpRequest should created an entity with plain/text when no content type specified" in {
-      val signedRequest :NewSignedRequest =
-        NewSignedRequest(
-          NewUnsignedRequest.fromStringBodyUtf8( httpMethod = "POST", uri = new URI("/"), body = "", headers = Map.empty), mauthHeadersMap)
+    "Generate a POST HttpRequest should created an entity with plain/text when no content type specified" in {
+      val signedRequest: NewSignedRequest =
+        NewSignedRequest(NewUnsignedRequest.fromStringBodyUtf8(httpMethod = "POST", uri = new URI("/"), body = "", headers = Map.empty), mauthHeadersMap)
       NewSignedRequestOps(signedRequest).toAkkaHttpRequest.entity.contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
 
@@ -158,7 +152,6 @@ class ImplicitsTest extends AnyWordSpec with Matchers {
         NewSignedRequest(NewUnsignedRequest.fromStringBodyUtf8("POST", new URI("/"), "", headers), mauthHeaders = mauthHeadersMap)
       NewSignedRequestOps(signedRequest).toAkkaHttpRequest.entity.contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
-     */
 
     "Generate a POST HttpRequest should created a entity with the binary content type" in {
       val headers = Map("Content-Type" -> ContentTypes.`application/octet-stream`.toString())


### PR DESCRIPTION
#### What is this PR for?

Fix - Add support to customize content-type (apply "text/plain(UTF-8)" by default) in mAuthV2

#### What are the relevant JIRA tickets?
[MCC-530719](https://jira.mdsol.com/browse/MCC-530719)

This is also related to this previous bugfix https://github.com/mdsol/mauth-jvm-clients/pull/71