### PR TITLE
[MCC-575954]fall back to V1 when V2 authentication fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0]
+### Changed
+- Fall back to V1 authentication when V2 authentication fails.
+
+## [2.0.5]
 ### Added
 - Add support for MWSV2 protocol in Java modules
 - Add support for MWSV2 protocol in Scala modules

--- a/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/Authenticator.java
+++ b/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/Authenticator.java
@@ -9,6 +9,9 @@ public interface Authenticator {
    * The validation process consists of recreating the mAuth hashed signature from the request data
    * and comparing it to the decrypted hash signature from the mAuth header.
    *
+   * mauth_client will authenticate with the highest protocol version present and if authentication fails
+   * will fallback to lower protocol versions (if provided)
+   *
    * @param mAuthRequest Data from the incoming HTTP request necessary to perform the validation.
    * @return True or false indicating if the request is valid or not with respect to mAuth.
    */

--- a/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
+++ b/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
@@ -106,15 +106,21 @@ public class RequestAuthenticator implements Authenticator {
 
     PublicKey clientPublicKey = clientPublicKeyProvider.getPublicKey(mAuthRequest.getAppUUID());
     if (mAuthRequest.getMauthVersion().equals(MAuthVersion.MWSV2)) {
-      boolean isValidated = validateSignatureV2(mAuthRequest, clientPublicKey);
-      if (!isValidated && !v2OnlyAuthenticate) {
-        isValidated = fallbackValidateSignatureV1(mAuthRequest, clientPublicKey);
+      boolean v2IsValidated = validateSignatureV2(mAuthRequest, clientPublicKey);
+      if (v2OnlyAuthenticate) {
+        return v2IsValidated;
       }
-      return isValidated;
+      else if (v2IsValidated) {
+        return v2IsValidated;
+      }
+      else {
+        return fallbackValidateSignatureV1(mAuthRequest, clientPublicKey);
+      }
     }
     else {
       return validateSignatureV1(mAuthRequest, clientPublicKey);
     }
+
   }
 
   // Check epoch time is not older than specified interval.

--- a/modules/mauth-authenticator/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
+++ b/modules/mauth-authenticator/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
@@ -54,9 +54,11 @@ class RequestAuthenticator(publicKeyProvider: ClientPublicKeyProvider, epochTime
               case MAuthVersion.MWS =>
                 validateSignatureV1(mAuthRequest, clientPublicKey)
               case MAuthVersion.MWSV2 =>
-                val isValidated = validateSignatureV2(mAuthRequest, clientPublicKey)
-                if (isValidated || v2OnlyAuthenticate)
-                  isValidated
+                val v2IsValidated = validateSignatureV2(mAuthRequest, clientPublicKey)
+                if (v2OnlyAuthenticate)
+                  v2IsValidated
+                else if (v2IsValidated)
+                  v2IsValidated
                 else
                   fallbackValidateSignatureV1(mAuthRequest, clientPublicKey)
             }

--- a/modules/mauth-authenticator/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
+++ b/modules/mauth-authenticator/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
@@ -159,4 +159,27 @@ trait RequestAuthenticatorBaseSpec extends AnyFlatSpec with BeforeAndAfterAll wi
       .build
   }
 
+  val WRONG_CLIENT_REQUEST_SIGNATURE_V2: String =
+    """aa2ht0OkDx20yWlPvOQn1jdTFaT3rS//3t+yl0VqiTgqeMae7x24/UzfD2WQ
+      |Bk6o226eQVnCloRjGgq9iLqIIf1wrAFy4CjEHPVCwKOcfbpVQBJYLCyL3Ilz
+      |VX6oDmV1Ghukk29mIlgmHGhfHPwGf3vMPvgCQ42GsnAKpRrQ9T4L2IWMM9gk
+      |WRAFYDXE3igTM+mWBz3IRrJMLnC2440N/KFNmwh3mVCDxIx/3D4xGhhiGZwA
+      |udVbIHmOG045CTSlajxWSNCbClM3nBmAzZn+wRD3DvdvHvDMiAtfVpz7rNLq
+      |2rBY2KRNJmPBaAV5ss30FC146jfyg7b8I9fenyauaw==""".stripMargin
+  private val CLIENT_REQUEST_HEADERS2 = new java.util.HashMap[String, String]()
+  CLIENT_REQUEST_HEADERS2.put(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, CLIENT_REQUEST_AUTHENTICATION_HEADER)
+  CLIENT_REQUEST_HEADERS2.put(MAuthRequest.X_MWS_TIME_HEADER_NAME, CLIENT_X_MWS_TIME_HEADER_VALUE)
+  CLIENT_REQUEST_HEADERS2
+    .put(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME, "MWSV2 " + EXISTING_CLIENT_APP_UUID.toString + ":" + WRONG_CLIENT_REQUEST_SIGNATURE_V2 + ";")
+  CLIENT_REQUEST_HEADERS2.put(MAuthRequest.MCC_TIME_HEADER_NAME, CLIENT_MCC_TIME_HEADER_VALUE)
+  def getRequestWithWrongV2Signature: MAuthRequest = {
+    MAuthRequest.Builder.get
+      .withHttpMethod(CLIENT_REQUEST_METHOD)
+      .withMauthHeaders(CLIENT_REQUEST_HEADERS2)
+      .withMessagePayload(CLIENT_REQUEST_BODY.getBytes(StandardCharsets.UTF_8))
+      .withResourcePath(CLIENT_REQUEST_PATH)
+      .withQueryParameters("")
+      .build
+  }
+
 }

--- a/modules/mauth-authenticator/src/test/scala/com/mdsol/mauth/RequestAuthenticatorSpec.scala
+++ b/modules/mauth-authenticator/src/test/scala/com/mdsol/mauth/RequestAuthenticatorSpec.scala
@@ -98,4 +98,18 @@ class RequestAuthenticatorSpec extends AnyFlatSpec with RequestAuthenticatorBase
     authenticator.authenticate(getRequestWithBinaryBodyV1) shouldBe true
   }
 
+  it should "validate the request with the validated V1 headers and wrong V2 signature" in {
+    //noinspection ConvertibleToMethodValue
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_MCC_TIME_HEADER_VALUE.toLong + 3)
+    (mockClientPublicKeyProvider.getPublicKey _).expects(EXISTING_CLIENT_APP_UUID).returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY))
+    authenticator.authenticate(getRequestWithWrongV2Signature) shouldBe true
+  }
+
+  it should "fail validating request with validated V1 headers and wrong V2 signature if V2 only is enabled" in {
+    //noinspection ConvertibleToMethodValue
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_MCC_TIME_HEADER_VALUE.toLong + 3)
+    (mockClientPublicKeyProvider.getPublicKey _).expects(EXISTING_CLIENT_APP_UUID).returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY))
+    authenticatorV2.authenticate(getRequestWithWrongV2Signature) shouldBe false
+  }
+
 }

--- a/modules/mauth-common/src/main/java/com/mdsol/mauth/MAuthRequest.java
+++ b/modules/mauth-common/src/main/java/com/mdsol/mauth/MAuthRequest.java
@@ -38,6 +38,8 @@ public class MAuthRequest {
   private final String resourcePath;
   private final String queryParameters;
   private final MAuthVersion mauthVersion;
+  private String xmwsSignature = null;
+  private String xmwsTime = null;
 
   /**
    * Create a Mauth request
@@ -126,6 +128,22 @@ public class MAuthRequest {
 
   public String getQueryParameters() {
     return queryParameters;
+  }
+
+  public String getXmwsSignature() {
+    return xmwsSignature;
+  }
+
+  public void setXmwsSignature(String xmwsSignature) {
+    this.xmwsSignature = xmwsSignature;
+  }
+
+  public String getXmwsTime() {
+    return xmwsTime;
+  }
+
+  public void setXmwsTime(String xmwsTime) {
+    this.xmwsTime = xmwsTime;
   }
 
   public MAuthVersion getMauthVersion() {
@@ -220,8 +238,17 @@ public class MAuthRequest {
           timeHeaderValue = mauthHeaders.get(X_MWS_TIME_HEADER_NAME);
         }
       }
-      return new MAuthRequest(authenticationHeaderValue, messagePayload, httpMethod,
-          timeHeaderValue, resourcePath, queryParameters);
+
+      MAuthRequest mAuthRequest = new MAuthRequest(authenticationHeaderValue, messagePayload,
+          httpMethod, timeHeaderValue, resourcePath, queryParameters);
+
+      if (mAuthRequest.getMauthVersion().equals(MAuthVersion.MWSV2)) {
+        mAuthRequest.setXmwsSignature(mauthHeaders.get(X_MWS_AUTHENTICATION_HEADER_NAME));
+        mAuthRequest.setXmwsTime(mauthHeaders.get(X_MWS_TIME_HEADER_NAME));
+      }
+
+      return mAuthRequest;
+
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.5-SNAPSHOT"
+version in ThisBuild := "2.1.0-SNAPSHOT"


### PR DESCRIPTION
As discussed in this https://docs.google.com/document/d/1UsKJfZeDJb3cbvi0B-z-KMXHrNEGo-GKhXi2k4OnMxU/edit#heading=h.k5ec2aaqcyc0
and same as in ruby https://github.com/mdsol/mauth-client-ruby/pull/38, this PR updates the logic to fall back to V1 authentication when V2 authentication fails.

Please review:
@jatcwang @austek @mcallonalvarez @mdsol/architecture-enablement
