### PR TITLE
[MCC-560247]Refactor mauth-signer with encoded path and query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use the encoded resource path and query parameters for Mauth singer
+- Fall back to V1 authentication when V2 authentication fails using Akka Http
 
 ## [4.0.0] - 2020-03-19
 ### Added

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
@@ -6,7 +6,7 @@ import java.security.Security
 import com.mdsol.mauth.test.utils.FakeMAuthServer.EXISTING_CLIENT_APP_UUID
 import com.mdsol.mauth.test.utils.FixturesLoader
 import com.mdsol.mauth.util.EpochTimeProvider
-import org.apache.http.client.methods.{HttpGet, HttpPost, HttpPut}
+import org.apache.http.client.methods.{HttpGet, HttpPost}
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
@@ -138,25 +138,30 @@ trait RequestAuthenticatorBaseSpec extends AnyFlatSpec with BeforeAndAfterAll wi
       .build
   }
 
-  val CLIENT_REQUEST_BINARY_APP_UUID = "5ff4257e-9c16-11e0-b048-0026bbfffe5e"
-  val CLIENT_X_MWS_TIME_HEADER_BINARY_VALUE = "1309891855"
-  val CLIENT_REQUEST_BINARY_PATH = "/v1/pictures"
+  val CLIENT_REQUEST_BINARY_APP_UUID = FixturesLoader.APP_UUID_V2
+  val CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE = FixturesLoader.EPOCH_TIME_V2
   val PUBLIC_KEY2: String = FixturesLoader.getPublicKey2
-  val CLIENT_REQUEST_SIGNATURE_BINARY_V1: String =
-    ("hDKYDRnzPFL2gzsru4zn7c7E7KpEvexeF4F5IR+puDxYXrMmuT2/fETZty5NkG" +
-      "GTZQ1nI6BTYGQGsU/73TkEAm7SvbJZcB2duLSCn8H5D0S1cafory1gnL1TpMP" +
-      "BlY8J/lq/Mht2E17eYw+P87FcpvDShINzy8GxWHqfquBqO8ml4XtirVEtAlI0" +
-      "xlkAsKkVq4nj7rKZUMS85mzogjUAJn3WgpGCNXVU+EK+qElW5QXk3I9uozByZ" +
-      "hwBcYt5Cnlg15o99+53wKzMMmdvFmVjA1DeUaSO7LMIuw4ZNLVdDcHJx7ZSpA" +
-      "KZ/EA34u1fYNECFcw5CSKOjdlU7JFr4o8Phw==").stripMargin
-  val CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER: String = "MWS " + CLIENT_REQUEST_BINARY_APP_UUID + ":" + CLIENT_REQUEST_SIGNATURE_BINARY_V1
+  val CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V1: String = "MWS " + FixturesLoader.APP_UUID_V2 + ":" + FixturesLoader.SIGNATURE_V1_BINARY
   def getRequestWithBinaryBodyV1: MAuthRequest = {
     MAuthRequest.Builder.get
-      .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER)
-      .withTimeHeaderValue(CLIENT_X_MWS_TIME_HEADER_BINARY_VALUE)
-      .withHttpMethod(HttpPut.METHOD_NAME)
+      .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V1)
+      .withTimeHeaderValue(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE)
+      .withHttpMethod(FixturesLoader.REQUEST_METHOD_V2)
       .withMessagePayload(FixturesLoader.getBinaryFileBody)
-      .withResourcePath(CLIENT_REQUEST_BINARY_PATH)
+      .withResourcePath(FixturesLoader.REQUEST_PATH_V2)
+      .withQueryParameters(FixturesLoader.REQUEST_QUERY_PARAMETERS_V2)
+      .build
+  }
+
+  val CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V2: String = "MWSV2 " + CLIENT_REQUEST_BINARY_APP_UUID + ":" + FixturesLoader.SIGNATURE_V2_BINARY
+  def getRequestWithBinaryBodyV2: MAuthRequest = {
+    MAuthRequest.Builder.get
+      .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V2)
+      .withTimeHeaderValue(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE)
+      .withHttpMethod(FixturesLoader.REQUEST_METHOD_V2)
+      .withMessagePayload(FixturesLoader.getBinaryFileBody)
+      .withResourcePath(FixturesLoader.REQUEST_PATH_V2)
+      .withQueryParameters(FixturesLoader.REQUEST_QUERY_PARAMETERS_V2)
       .build
   }
 

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorSpec.scala
@@ -91,11 +91,20 @@ class RequestAuthenticatorSpec extends AnyFlatSpec with RequestAuthenticatorBase
 
   it should "validate a valid request with binary body for V1" in {
     //noinspection ConvertibleToMethodValue
-    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_X_MWS_TIME_HEADER_BINARY_VALUE.toLong + 3)
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE.toLong + 3)
     (mockClientPublicKeyProvider.getPublicKey _)
       .expects(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID))
       .returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY2))
     authenticator.authenticate(getRequestWithBinaryBodyV1) shouldBe true
+  }
+
+  it should "validate a valid request with binary body for V2" in {
+    //noinspection ConvertibleToMethodValue
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE.toLong + 5)
+    (mockClientPublicKeyProvider.getPublicKey _)
+      .expects(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID))
+      .returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY2))
+    authenticator.authenticate(getRequestWithBinaryBodyV2) shouldBe true
   }
 
   it should "validate the request with the validated V1 headers and wrong V2 signature" in {

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/scaladsl/utils/RequestAuthenticatorSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/scaladsl/utils/RequestAuthenticatorSpec.scala
@@ -105,10 +105,19 @@ class RequestAuthenticatorSpec extends AnyFlatSpec with RequestAuthenticatorBase
   it should "authenticate a valid request with binary payload" in {
     val client: ClientPublicKeyProvider = mock[ClientPublicKeyProvider]
     (client.getPublicKey _).expects(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID)).returns(Future(Some(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY2))))
-    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_X_MWS_TIME_HEADER_BINARY_VALUE.toLong + 3)
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE.toLong + 3)
     val authenticator = new RequestAuthenticator(client, mockEpochTimeProvider)
 
     whenReady(authenticator.authenticate(getRequestWithBinaryBodyV1))(validationResult => validationResult shouldBe true)
+  }
+
+  it should "authenticate a valid request with binary payload for V2" in {
+    val client: ClientPublicKeyProvider = mock[ClientPublicKeyProvider]
+    (client.getPublicKey _).expects(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID)).returns(Future(Some(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY2))))
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE.toLong + 5)
+    val authenticator = new RequestAuthenticator(client, mockEpochTimeProvider)
+
+    whenReady(authenticator.authenticate(getRequestWithBinaryBodyV2))(validationResult => validationResult shouldBe true)
   }
 
   it should "validate the request with the validated V1 headers and wrong V2 signature" in clientContext { client =>

--- a/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthSignatureHelperSpec.scala
+++ b/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthSignatureHelperSpec.scala
@@ -89,8 +89,8 @@ class MAuthSignatureHelperSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "correctly encode query string with special chars" in {
-    val queryString = "key=-_.~!@#$%^*()+{}|:\"'`<>?"
-    val expectedString = "key=-_.~%21%40%23%24%25%5E%2A%28%29%20%7B%7D%7C%3A%22%27%60%3C%3E%3F"
+    val queryString = "key2=asdf+f&key=%21%40%23"
+    val expectedString = "key=%21%40%23&key2=asdf%20f"
     MAuthSignatureHelper.generateEncryptedQueryParams(queryString) shouldBe expectedString
   }
 

--- a/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthSignatureHelperSpec.scala
+++ b/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthSignatureHelperSpec.scala
@@ -24,11 +24,11 @@ class MAuthSignatureHelperSpec extends AnyFlatSpec with Matchers {
   private val TEST_PRIVATE_KEY = getPrivateKeyFromString(FixturesLoader.getPrivateKey2)
 
   // the same test data with ruby and python
-  private val CLIENT_APP_UUID_V2 = "5ff4257e-9c16-11e0-b048-0026bbfffe5e"
-  private val CLIENT_REQUEST_METHOD_V2 = "PUT"
-  private val CLIENT_REQUEST_PATH_V2 = "/v1/pictures"
-  private val CLIENT_REQUEST_QUERY_PARAMETERS_V2 = "key=-_.~ !@#$%^*()+{}|:\"'`<>?&∞=v&キ=v&0=v&a=v&a=b&a=c&a=a&k=&k=v"
-  private val TEST_EPOCH_TIME_V2 = "1309891855"
+  private val CLIENT_APP_UUID_V2 = FixturesLoader.APP_UUID_V2
+  private val CLIENT_REQUEST_METHOD_V2 = FixturesLoader.REQUEST_METHOD_V2
+  private val CLIENT_REQUEST_PATH_V2 = FixturesLoader.REQUEST_PATH_V2
+  private val CLIENT_REQUEST_QUERY_PARAMETERS_V2 = FixturesLoader.REQUEST_QUERY_PARAMETERS_V2
+  private val TEST_EPOCH_TIME_V2 = FixturesLoader.EPOCH_TIME_V2
 
   behavior of "MAuthSignatureHelper"
 
@@ -89,8 +89,8 @@ class MAuthSignatureHelperSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "correctly encode query string with special chars" in {
-    val queryString = "key=-_.~ !@#$%^*()+{}|:\"'`<>?"
-    val expectedString = "key=-_.~%20%21%40%23%24%25%5E%2A%28%29%2B%7B%7D%7C%3A%22%27%60%3C%3E%3F"
+    val queryString = "key=-_.~!@#$%^*()+{}|:\"'`<>?"
+    val expectedString = "key=-_.~%21%40%23%24%25%5E%2A%28%29%20%7B%7D%7C%3A%22%27%60%3C%3E%3F"
     MAuthSignatureHelper.generateEncryptedQueryParams(queryString) shouldBe expectedString
   }
 
@@ -149,12 +149,7 @@ class MAuthSignatureHelperSpec extends AnyFlatSpec with Matchers {
       FixturesLoader.getBinaryFileBody,
       TEST_EPOCH_TIME_V2
     )
-    val expectedString = ("GpZIRB8RIxlfsjcROBElMEwa0r7jr632GkBe+R8lOv72vVV7bFMbJwQUHYm6vL/N" +
-      "KC7g4lJwvWcF60lllIUGwv/KWUOQwerqo5yCNoNumxjgDKjq7ILl8iFxsrV9LdvxwGyEBEwAPKzoTmW9xrad" +
-      "xmjn4ZZVMnQKEMns6iViBkwaAW2alp4ZtVfJIZHRRyiuFnITWH1PniyG0kI4Li16kY25VfmzfNkdAi0Cnl27" +
-      "Cy1+DtAl1zVnz6ObMAdtmsEtplvlqsRCRsdd37VfuUxUlolNpr5brjzTwXksScUjX80/HMnui5ZlFORGjHeb" +
-      "eZG5QVCouZPKBWTWsELGx1iyaw==").stripMargin.replaceAll("\n", "")
-    MAuthSignatureHelper.encryptSignatureRSA(TEST_PRIVATE_KEY, testString) shouldBe expectedString
+    MAuthSignatureHelper.encryptSignatureRSA(TEST_PRIVATE_KEY, testString) shouldBe FixturesLoader.SIGNATURE_V2_BINARY
   }
 
   it should "correctly generate signature with empty body for V2" in {
@@ -166,12 +161,55 @@ class MAuthSignatureHelperSpec extends AnyFlatSpec with Matchers {
       Array.empty,
       TEST_EPOCH_TIME_V2
     )
-    val expectedString = ("jDB6fhwUA11ZSLb2W4ueS4l9hsguqmgcRez58kUo25iuMT5Uj9wWz+coHSpOd39B0" +
-      "cNW5D5UY6nWifw4RJIv/q8MdqS43WVgnCDSrNsSxpQ/ic6U3I3151S69PzSRZ+aR/I5A85Q9FgWB6wDNf4iX/" +
-      "BmZopfd5XjsLEyDymTRYedmB4DmONlTrsjVPs1DS2xY5xQyxIcxEUpVGDfTNroRTu5REBTttWbUB7BRXhKCc2" +
-      "pfRnUYPBo4Fa7nM8lI7J1/jUasMMLelr6hvcc6t21RCHhf4p9VlpokUOdN8slXU/kkC+OMUE04I021AUnZSpd" +
-      "hd/IoVR1JJDancBRzWA2HQ==").stripMargin.replaceAll("\n", "")
-    MAuthSignatureHelper.encryptSignatureRSA(TEST_PRIVATE_KEY, testString) shouldBe expectedString
+    MAuthSignatureHelper.encryptSignatureRSA(TEST_PRIVATE_KEY, testString) shouldBe FixturesLoader.SIGNATURE_V2_EMPTY
   }
 
+  it should "normalize path: correctly generate signature for V2" in {
+    val pathList = Array("/./v1/pictures", "/v1//pictures")
+    for (resourcePath <- pathList) {
+      val testString = MAuthSignatureHelper.generateStringToSignV2(
+        UUID.fromString(CLIENT_APP_UUID_V2),
+        CLIENT_REQUEST_METHOD_V2,
+        resourcePath,
+        CLIENT_REQUEST_QUERY_PARAMETERS_V2,
+        FixturesLoader.getBinaryFileBody,
+        TEST_EPOCH_TIME_V2
+      )
+      MAuthSignatureHelper.encryptSignatureRSA(TEST_PRIVATE_KEY, testString) shouldBe FixturesLoader.SIGNATURE_V2_BINARY
+    }
+  }
+
+  it should "correctly normalize paths" in {
+    // define of test cases: testString, expectedString
+    val testCases = Array(
+      Array("/example/sample", "/example/sample"),
+      Array("/example/sample/..", "/example/"),
+      Array("/example/sample/../..", "/"),
+      Array("/example/sample/../../../..", "/"),
+      Array("/example//sample/", "/example/sample/"),
+      Array("//example///sample/", "/example/sample/"),
+      Array("/example//./.", "/example/"),
+      Array("/./example/./.", "/example/"),
+      Array("/%2a%80", "/%2A%80"),
+      Array("/example/", "/example/")
+    )
+    for (i <- 0 to testCases.length - 1) {
+      MAuthSignatureHelper.normalizePath(testCases(i)(0)) shouldBe testCases(i)(1)
+    }
+  }
+
+  it should "correctly encode, sort query parameters" in {
+    // define of test cases: testString, expectedString
+    val testCases = Array(
+      Array("k=%7E", "k=~"),
+      Array("k=%20", "k=%20"),
+      Array("k=&k=v", "k=&k=v"),
+      Array("k=%7E&k=~&k=%40&k=a", "k=%40&k=a&k=~&k=~"),
+      Array("a=b&a=c&a=a", "a=a&a=b&a=c"),
+      Array("", "")
+    )
+    for (i <- 0 to testCases.length - 1) {
+      MAuthSignatureHelper.generateEncryptedQueryParams(testCases(i)(0)) shouldBe testCases(i)(1)
+    }
+  }
 }

--- a/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/MAuthHttpRequestSigner.java
+++ b/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/MAuthHttpRequestSigner.java
@@ -30,8 +30,8 @@ class MAuthHttpRequestSigner {
     String uriString = request.getUri();
     try {
       URI uri = new URI(uriString);
-      uriString = uri.getPath();
-      queryString = uri.getQuery();
+      uriString = uri.getRawPath();
+      queryString = uri.getRawQuery();
     } catch (URISyntaxException e) {
       logger.error("Couldn't get request uri", e);
     }

--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
@@ -81,7 +81,7 @@ class MAuthRequestSigner(appUUID: UUID, privateKey: PrivateKey, epochTimeProvide
   }
 
   override def signRequest(request: NewUnsignedRequest): NewSignedRequest = {
-    val headers = generateRequestHeaders(request.httpMethod, request.uri.getPath, request.body, request.uri.getQuery).asScala.toMap
+    val headers = generateRequestHeaders(request.httpMethod, request.uri.getRawPath, request.body, request.uri.getRawQuery).asScala.toMap
     NewSignedRequest(
       request,
       headers

--- a/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/MAuthRequestSignerSpec.scala
+++ b/modules/mauth-signer-akka-http/src/test/scala/com/mdsol/mauth/MAuthRequestSignerSpec.scala
@@ -137,6 +137,20 @@ class MAuthRequestSignerSpec extends AnyFlatSpec with Matchers with HttpClient w
     authHeaders(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_GET_MCC_AUTHENTICATION_HEADER
   }
 
+  it should "add authentication header to a request for V2 with the encoded-normalize path" in {
+    val TEST_UUID = FixturesLoader.APP_UUID_V2
+    val EXPECTED_SIGNATURE_V2 = FixturesLoader.SIGNATURE_NORMALIZE_PATH_V2
+    val EXPECTED_AUTHENTICATION_HEADER = s"""MWSV2 $TEST_UUID:$EXPECTED_SIGNATURE_V2;"""
+    val eTimeProvider: EpochTimeProvider = new EpochTimeProvider() { override def inSeconds(): Long = FixturesLoader.EPOCH_TIME_V2.toLong }
+    val newSigner: MAuthRequestSigner = MAuthRequestSigner(UUID.fromString(TEST_UUID), FixturesLoader.getPrivateKey2, eTimeProvider, v2OnlySignRequests = true)
+
+    newSigner
+      .signRequest(
+        NewUnsignedRequest.fromStringBodyUtf8(httpMethod = "GET", uri = new URI(FixturesLoader.REQUEST_NORMALIZE_PATH), body = "", headers = Map.empty)
+      )
+      .mauthHeaders(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_AUTHENTICATION_HEADER
+  }
+
   it should "correctly send a customized content-type header" in {
     service.stubFor(
       post(urlPathEqualTo(s"/v1/test"))

--- a/modules/mauth-signer-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientRequestSigner.java
+++ b/modules/mauth-signer-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientRequestSigner.java
@@ -6,19 +6,16 @@ import com.mdsol.mauth.exceptions.MAuthSigningException;
 import com.mdsol.mauth.util.CurrentEpochTimeProvider;
 import com.mdsol.mauth.util.EpochTimeProvider;
 import org.apache.http.HttpEntityEnclosingRequest;
-import org.apache.http.NameValuePair;
 import org.apache.http.ParseException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -70,19 +67,7 @@ public class HttpClientRequestSigner extends DefaultSigner {
       }
     }
 
-    URIBuilder newBuilder = new URIBuilder(request.getURI());
-    List<NameValuePair> params = newBuilder.getQueryParams();
-
-    StringBuilder queryParams = new StringBuilder();
-    for (NameValuePair param : params)
-    {
-      if(queryParams.length() > 0){
-        queryParams.append('&');
-      }
-      queryParams.append(param.getName()).append('=').append(param.getValue());
-    }
-
-    Map<String, String> mauthHeaders = generateRequestHeaders(httpVerb, request.getURI().getPath(), body, queryParams.toString());
+    Map<String, String> mauthHeaders = generateRequestHeaders(httpVerb, request.getURI().getRawPath(), body, request.getURI().getRawQuery());
     for (String key : mauthHeaders.keySet()) {
       request.addHeader(key, mauthHeaders.get(key));
     }

--- a/modules/mauth-signer/src/test/scala/com/mdsol/mauth/DefaultSignerSpec.scala
+++ b/modules/mauth-signer/src/test/scala/com/mdsol/mauth/DefaultSignerSpec.scala
@@ -141,28 +141,14 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
 
   it should "generated headers for binary payload for both V1 and V2 if V2 only is disabled" in {
     //noinspection ConvertibleToMethodValue
-    val CLIENT_REQUEST_BINARY_APP_UUID = "5ff4257e-9c16-11e0-b048-0026bbfffe5e"
-    val CLIENT_REQUEST_BINARY_EPOCH_TIME: Long = 1309891855L
-    val CLIENT_REQUEST_BINARY_PATH = "/v1/pictures"
-    val CLIENT_REQUEST_QUERY_PARAMETERS = "key=-_.~ !@#$%^*()+{}|:\"'`<>?&∞=v&キ=v&0=v&a=v&a=b&a=c&a=a&k=&k=v"
+    val CLIENT_REQUEST_BINARY_APP_UUID = FixturesLoader.APP_UUID_V2
+    val CLIENT_REQUEST_BINARY_EPOCH_TIME: Long = FixturesLoader.EPOCH_TIME_V2.toLong
+    val CLIENT_REQUEST_BINARY_PATH = FixturesLoader.REQUEST_PATH_V2
+    val CLIENT_REQUEST_QUERY_PARAMETERS = FixturesLoader.REQUEST_QUERY_PARAMETERS_V2
     val mAuthSigner = new DefaultSigner(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID), FixturesLoader.getPrivateKey2, mockEpochTimeProvider, false)
     (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_EPOCH_TIME)
-    val EXPECTED_AUTHENTICATION_HEADER_V1: String =
-      s"""MWS $CLIENT_REQUEST_BINARY_APP_UUID:hDKYDRnzPFL2gzsru4zn7c7E7
-         |KpEvexeF4F5IR+puDxYXrMmuT2/fETZty5NkGGTZQ1nI6BTYGQGsU/73TkEAm
-         |7SvbJZcB2duLSCn8H5D0S1cafory1gnL1TpMPBlY8J/lq/Mht2E17eYw+P87F
-         |cpvDShINzy8GxWHqfquBqO8ml4XtirVEtAlI0xlkAsKkVq4nj7rKZUMS85mzo
-         |gjUAJn3WgpGCNXVU+EK+qElW5QXk3I9uozByZhwBcYt5Cnlg15o99+53wKzMM
-         |mdvFmVjA1DeUaSO7LMIuw4ZNLVdDcHJx7ZSpAKZ/EA34u1fYNECFcw5CSKOjd
-         |lU7JFr4o8Phw==""".stripMargin.replaceAll("\n", "")
-    val EXPECTED_AUTHENTICATION_HEADER_V2: String =
-      s"""MWSV2 $CLIENT_REQUEST_BINARY_APP_UUID:GpZIRB8RIxlfsjcROBElMEw
-         |a0r7jr632GkBe+R8lOv72vVV7bFMbJwQUHYm6vL/NKC7g4lJwvWcF60lllIUG
-         |wv/KWUOQwerqo5yCNoNumxjgDKjq7ILl8iFxsrV9LdvxwGyEBEwAPKzoTmW9x
-         |radxmjn4ZZVMnQKEMns6iViBkwaAW2alp4ZtVfJIZHRRyiuFnITWH1PniyG0k
-         |I4Li16kY25VfmzfNkdAi0Cnl27Cy1+DtAl1zVnz6ObMAdtmsEtplvlqsRCRsd
-         |d37VfuUxUlolNpr5brjzTwXksScUjX80/HMnui5ZlFORGjHebeZG5QVCouZPK
-         |BWTWsELGx1iyaw==;""".stripMargin.replaceAll("\n", "")
+    val EXPECTED_AUTHENTICATION_HEADER_V1: String = s"""MWS $CLIENT_REQUEST_BINARY_APP_UUID:${FixturesLoader.SIGNATURE_V1_BINARY}"""
+    val EXPECTED_AUTHENTICATION_HEADER_V2: String = s"""MWSV2 $CLIENT_REQUEST_BINARY_APP_UUID:${FixturesLoader.SIGNATURE_V2_BINARY};"""
     val headers: Map[String, String] =
       mAuthSigner.generateRequestHeaders("PUT", CLIENT_REQUEST_BINARY_PATH, FixturesLoader.getBinaryFileBody, CLIENT_REQUEST_QUERY_PARAMETERS).asScala.toMap
     headers(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_AUTHENTICATION_HEADER_V1

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FixturesLoader.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FixturesLoader.java
@@ -7,6 +7,20 @@ import java.nio.charset.Charset;
 
 public class FixturesLoader {
 
+  // fixtures of Cross platform testing for mAuth signatures (match with PrivateKey2 & PublicKey2)
+  public final static String APP_UUID_V2 ="5ff4257e-9c16-11e0-b048-0026bbfffe5e";
+  public final static String EPOCH_TIME_V2 = "1309891855";
+
+  public final static String REQUEST_METHOD_V2 = "PUT";
+  public final static String REQUEST_PATH_V2 = "/v1/pictures";
+  public final static String REQUEST_QUERY_PARAMETERS_V2 = "key=-_.~!@#$%^*()+{}|:\"'`<>?&∞=v&キ=v&0=v&a=v&a=b&a=c&a=a&k=&k=v";
+  public final static String SIGNATURE_V1_BINARY = "hDKYDRnzPFL2gzsru4zn7c7E7KpEvexeF4F5IR+puDxYXrMmuT2/fETZty5NkGGTZQ1nI6BTYGQGsU/73TkEAm7SvbJZcB2duLSCn8H5D0S1cafory1gnL1TpMPBlY8J/lq/Mht2E17eYw+P87FcpvDShINzy8GxWHqfquBqO8ml4XtirVEtAlI0xlkAsKkVq4nj7rKZUMS85mzogjUAJn3WgpGCNXVU+EK+qElW5QXk3I9uozByZhwBcYt5Cnlg15o99+53wKzMMmdvFmVjA1DeUaSO7LMIuw4ZNLVdDcHJx7ZSpAKZ/EA34u1fYNECFcw5CSKOjdlU7JFr4o8Phw==";
+  public final static String SIGNATURE_V2_BINARY = "kNmQchPnfSZOo29GHHDcp+res452+IIiWK/h7HmPdFsTU510X+eWPLaYONmfd2fMAuVLncDAiOPxyOS4WXap69szL37k9537ujnEU15I+j+vINTspCnAIbtZ9ia35c+gQyPgNQo7F1RxNl1P3hfXJ4qNXIrMSc/DlKpieNzmXQFPFs9zZxK5VPvdS0QBsuQFSMN71o2Rupf+NRStxvH55pVej/mjJj4PbeCgAX2N6Vi0dqU2GLgcx+0U5j5FphLUIdqF6/6FKRqPRSCLX5hEyFf2c4stRnNWSpP/y/gGFtdIVxFzKEe42cL3FmYSM4YFTKn3wGgViw0W+CzkbDXJqQ==";
+  public final static String SIGNATURE_V2_EMPTY = "rUB9ZnFqqjuNUv5new2vAplAjOh5eTEMYJjMm2G32jkPYqIhUmffEErkWbzOIrHzVfsW9zwgyEO+QRmGSvDDkYSa0ecDQ0/HDUokQoQ0yuZGInztXDJVPDKVy6MDxLcNwnwFo1qHtANL3dYrGAai11AamPU2Hvjf2BcNYLnryIbP3/8ChLRbQTu9rw/v7bmC+owG1BchLIBuBhsr33yiuGD/AfbxqOD9jVb3rZsFvM1/O6aLzT3enNgKxWlpZl+vgnnIHBtdiYl/HGLoX5BMuNsaxpDT7OS4cBIsgkkszQe17vNotnMUUV2WklOZ27x7Uv77LbrY0LgEdzofkv6v3Q==";
+
+  public final static String REQUEST_NORMALIZE_PATH = "/%cf%80";
+  public final static String SIGNATURE_NORMALIZE_PATH_V2 = "QtD4t3uO5xYRhT/QDxJm3Dd9zH79hLsUjL9IRvUhana8cS9/JE7dxpsBC17Owh+6cSvTENa1FjKqcPoRgZKACR/pRqmx43+Ha2twdWN2p+Zt+plBZ56ylTv1yKpOCEO6FM/QPEnJtY1DezKmu/EILhkfaLdVh5JTq665SeD1LRv46MVyhAN1BoqQPJI/BLddQRpmmTvmPtKBK5VFhcJs6ZfD2YgFxsKajhGE+posgRjkQ18D1CV54v1kQBK9iiImN1h8G1k/bDKfDjpgTiC7A+n5kJa5PWU+pP9rseGnagEV2bIiA67cObLqRH7kjnKI8PK63cDKJoO7Zfv4zFnrbw==";
+
   public static String getPublicKey() {
     try {
       return IOUtils.toString(FixturesLoader.class.getResourceAsStream("/keys/fake_publickey.pem"), Charset.defaultCharset());


### PR DESCRIPTION
This PR includes the changes:
1. refactor mauth-signer to use the encoded resource path and query parameters for V2(sync up mauth-client-ruby);
2. normalize the resource path;
3. update the tests;

@mdsol/architecture-enablement @austek @jatcwang 