### PR TITLE
[MCC-620147] : mauth-proxy changes to work with POST and PATCH

### DIFF
--- a/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/MAuthHttpRequestSigner.java
+++ b/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/MAuthHttpRequestSigner.java
@@ -1,7 +1,6 @@
 package com.mdsol.mauth.proxy;
 
 import com.mdsol.mauth.Signer;
-
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import org.slf4j.Logger;
@@ -9,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 class MAuthHttpRequestSigner {
@@ -21,11 +21,10 @@ class MAuthHttpRequestSigner {
 
   void signRequest(HttpRequest request) {
     final String verb = request.getMethod().name();
-
-    byte[] requestPayload = null;
+    String requestPayload = null;
     String queryString = null;
     if (request instanceof FullHttpRequest) {
-      requestPayload = ((FullHttpRequest) request).content().array();
+      requestPayload = ((FullHttpRequest)request).content().toString(StandardCharsets.UTF_8);
     }
     String uriString = request.getUri();
     try {
@@ -37,8 +36,12 @@ class MAuthHttpRequestSigner {
     }
 
     logger.debug("Generating request headers for Verb: '" + verb + "' URI: '" + uriString +
-        "' Payload: " + requestPayload.toString() + "' Query parameters: " + queryString);
-    Map<String, String> mAuthHeaders = httpClientRequestSigner.generateRequestHeaders(verb, uriString, requestPayload, queryString);
+            "' Payload: " + requestPayload + "' Query parameters: " + queryString);
+    Map<String, String> mAuthHeaders = httpClientRequestSigner
+            .generateRequestHeaders(verb,
+                    uriString,
+                    requestPayload != null ? requestPayload.getBytes() : new byte[0],
+                    queryString);
     mAuthHeaders.forEach((key, value) -> request.headers().add(key, value));
   }
 }

--- a/modules/mauth-proxy/src/test/scala/com/mdsol/mauth/proxy/ProxyServerSpec.scala
+++ b/modules/mauth-proxy/src/test/scala/com/mdsol/mauth/proxy/ProxyServerSpec.scala
@@ -118,6 +118,44 @@ class ProxyServerSpec extends AnyFlatSpec with Matchers with MockFactory with Be
     response.getStatusLine.getStatusCode shouldBe HttpStatus.SC_OK
   }
 
+  it should "POST - Fail if proxy responds with 404" in {
+    service.stubFor(
+      post(urlEqualTo("/my/failure_resource?k=v"))
+        .withHeader(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, containing("MWS "))
+        .withHeader(MAuthRequest.X_MWS_TIME_HEADER_NAME, matching(".*"))
+        .withHeader(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME, containing("MWSV2 "))
+        .withHeader(MAuthRequest.MCC_TIME_HEADER_NAME, matching(".*"))
+        .willReturn(notFound)
+    )
+
+    val proxy = new HttpHost("localhost", proxyServer.getPort)
+    val routePlanner = new DefaultProxyRoutePlanner(proxy)
+    val httpClient = HttpClients.custom.setRoutePlanner(routePlanner).build
+    val request = new HttpPost(BASE_URL + ":" + service.port + "/my/failure_resource?k=v")
+
+    val response = httpClient.execute(request)
+    response.getStatusLine.getStatusCode shouldBe HttpStatus.SC_NOT_FOUND
+  }
+
+  it should "PATCH - Fail if proxy responds with 404" in {
+    service.stubFor(
+      patch(urlEqualTo("/my/failure_resource?k=v"))
+        .withHeader(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, containing("MWS "))
+        .withHeader(MAuthRequest.X_MWS_TIME_HEADER_NAME, matching(".*"))
+        .withHeader(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME, containing("MWSV2 "))
+        .withHeader(MAuthRequest.MCC_TIME_HEADER_NAME, matching(".*"))
+        .willReturn(notFound)
+    )
+
+    val proxy = new HttpHost("localhost", proxyServer.getPort)
+    val routePlanner = new DefaultProxyRoutePlanner(proxy)
+    val httpClient = HttpClients.custom.setRoutePlanner(routePlanner).build
+    val request = new HttpPatch(BASE_URL + ":" + service.port + "/my/failure_resource?k=v")
+
+    val response = httpClient.execute(request)
+    response.getStatusLine.getStatusCode shouldBe HttpStatus.SC_NOT_FOUND
+  }
+
   private def execute(proxyServerPort: Int, verb: String): CloseableHttpResponse = {
     val proxy = new HttpHost("localhost", proxyServerPort)
     val routePlanner = new DefaultProxyRoutePlanner(proxy)

--- a/modules/mauth-proxy/src/test/scala/com/mdsol/mauth/proxy/ProxyServerSpec.scala
+++ b/modules/mauth-proxy/src/test/scala/com/mdsol/mauth/proxy/ProxyServerSpec.scala
@@ -5,7 +5,8 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.mdsol.mauth.MAuthRequest
 import com.typesafe.config.ConfigFactory
-import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.{CloseableHttpResponse, HttpGet, HttpPatch, HttpPost}
+import org.apache.http.entity.ByteArrayEntity
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner
 import org.apache.http.{HttpHost, HttpStatus}
@@ -19,6 +20,7 @@ class ProxyServerSpec extends AnyFlatSpec with Matchers with MockFactory with Be
   private val MY_RESOURCE = "/my/resource"
   private val QUERY_PARAMETERS = "k1=v1&k2=v2"
   private val MY_RESOURCE_WITH_PARAMS = MY_RESOURCE + "?" + QUERY_PARAMETERS
+  private val MY_REQUEST_PAYLOAD = "{k1:v1, k2:v2}"
   var service = new WireMockServer(wireMockConfig.dynamicPort)
   val proxyServer = new ProxyServer(new ProxyConfig(ConfigFactory.load.resolve))
 
@@ -86,4 +88,48 @@ class ProxyServerSpec extends AnyFlatSpec with Matchers with MockFactory with Be
     response.getStatusLine.getStatusCode shouldBe HttpStatus.SC_OK
   }
 
+  it should "POST - correctly modify request with request payload" in {
+    service.stubFor(
+      post(urlEqualTo(MY_RESOURCE_WITH_PARAMS))
+        .withRequestBody(containing(""))
+        .withHeader(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, containing("MWS "))
+        .withHeader(MAuthRequest.X_MWS_TIME_HEADER_NAME, matching(".*"))
+        .withHeader(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME, containing("MWSV2 "))
+        .withHeader(MAuthRequest.MCC_TIME_HEADER_NAME, matching(".*"))
+        .willReturn(created)
+    )
+
+    val response = execute(proxyServer.getPort, "post")
+    response.getStatusLine.getStatusCode shouldBe HttpStatus.SC_CREATED
+  }
+
+  it should "PATCH - correctly modify request with request payload" in {
+    service.stubFor(
+      patch(urlEqualTo(MY_RESOURCE_WITH_PARAMS))
+        .withRequestBody(containing(""))
+        .withHeader(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME, containing("MWS "))
+        .withHeader(MAuthRequest.X_MWS_TIME_HEADER_NAME, matching(".*"))
+        .withHeader(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME, containing("MWSV2 "))
+        .withHeader(MAuthRequest.MCC_TIME_HEADER_NAME, matching(".*"))
+        .willReturn(ok("success"))
+    )
+
+    val response = execute(proxyServer.getPort, "patch")
+    response.getStatusLine.getStatusCode shouldBe HttpStatus.SC_OK
+  }
+
+  private def execute(proxyServerPort: Int, verb: String): CloseableHttpResponse = {
+    val proxy = new HttpHost("localhost", proxyServerPort)
+    val routePlanner = new DefaultProxyRoutePlanner(proxy)
+    val httpClient = HttpClients.custom.setRoutePlanner(routePlanner).build
+    if (verb.equals("post")) {
+      val request = new HttpPost(BASE_URL + ":" + service.port + MY_RESOURCE_WITH_PARAMS)
+      request.setEntity(new ByteArrayEntity(MY_REQUEST_PAYLOAD.getBytes("UTF-8")))
+      httpClient.execute(request)
+    } else {
+      val request = new HttpPatch(BASE_URL + ":" + service.port + MY_RESOURCE_WITH_PARAMS)
+      request.setEntity(new ByteArrayEntity(MY_REQUEST_PAYLOAD.getBytes("UTF-8")))
+      httpClient.execute(request)
+    }
+  }
 }


### PR DESCRIPTION
This PR includes the changes:
  1. refactor mauth-proxy to accept POST and PATCH request. (it was failing with 
                 java.lang.UnsupportedOperationException: direct buffer at com.mdsol.mauth.proxy.MAuthHttpRequestSigner.signRequest(MAuthHttpRequestSigner.java:28)
  2. update the tests