### PR TITLE
[MCC-621192]Make the signing protocol versions configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace `V2_ONLY_SIGN_REQUESTS` option with `MAUTH_SIGN_VERSIONS` option and set the default to `v2` only
 
 ## [4.0.2] - 2020-06-10
 

--- a/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyConfig.java
+++ b/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyConfig.java
@@ -1,21 +1,27 @@
 package com.mdsol.mauth.proxy;
 
+import com.mdsol.mauth.MAuthVersion;
+
 import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.runtime.Static;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 public class ProxyConfig {
   private static final Logger logger = LoggerFactory.getLogger(ProxyConfig.class);
 
-  public static final String V2_ONLY_SIGN_REQUESTS = "mauth.v2_only_sign_requests";
-  public static final String V2_ONLY_AUTHTICATE = "mauth.v2_only_authenticate";
+  public static final String SIGN_VERSIONS = "mauth.sign_versions";
+  public static final String V2_ONLY_AUTHENTICATE = "mauth.v2_only_authenticate";
   private final int proxyPort;
   private final int bufferSizeInByes;
   private String privateKey;
   private final UUID appUuid;
-  private boolean v2OnlySignRequests = false;
+  private List<MAuthVersion> signVersions;
   private boolean v2OnlyAuthenticate = false;
 
   public ProxyConfig(Config config) {
@@ -24,18 +30,18 @@ public class ProxyConfig {
       config.getInt("proxy.buffer_size_in_bytes"),
       UUID.fromString(config.getString("app.uuid")),
       config.getString("app.private_key"),
-      config.getBoolean(V2_ONLY_SIGN_REQUESTS),
-      config.getBoolean(V2_ONLY_AUTHTICATE)
+      config.getString(SIGN_VERSIONS),
+      config.getBoolean(V2_ONLY_AUTHENTICATE)
     );
   }
 
   public ProxyConfig(int proxyPort, int bufferSizeInByes, UUID appUuid, String privateKey,
-      boolean v2OnlySignRequests, boolean v2OnlyAuthenticate) {
+                     String signVersions, boolean v2OnlyAuthenticate) {
     this.proxyPort = proxyPort;
     this.bufferSizeInByes = bufferSizeInByes;
     this.appUuid = appUuid;
     this.privateKey = privateKey;
-    this.v2OnlySignRequests = v2OnlySignRequests;
+    this.signVersions = getSignVersions(signVersions);
     this.v2OnlyAuthenticate = v2OnlyAuthenticate;
   }
 
@@ -54,8 +60,35 @@ public class ProxyConfig {
   public UUID getAppUuid() {
     return appUuid;
   }
-  public boolean isV2OnlySignRequests() {
-    return v2OnlySignRequests;
+
+  public List<MAuthVersion> getSignVersions() { return signVersions; }
+
+  static public List<MAuthVersion> getSignVersions(String signVersionsStr) {
+    List<MAuthVersion> signVersions = new ArrayList();
+    List<String> unrecognizedVersions = new ArrayList();
+    List<String> versionList = Arrays.asList(signVersionsStr.trim().toLowerCase().split(","));
+    versionList.forEach(e -> {
+      switch (e.trim()) {
+        case "v1":
+          signVersions.add(MAuthVersion.MWS);
+          break;
+        case "v2":
+          signVersions.add(MAuthVersion.MWSV2);
+          break;
+        default:
+          unrecognizedVersions.add(e.trim());
+          break;
+      }
+    });
+    if (signVersions.isEmpty())
+      signVersions.add(MAuthVersion.MWSV2);
+
+    if (!unrecognizedVersions.isEmpty())
+      logger.warn("unrecognized versions to sign requests: " + unrecognizedVersions.toString());
+
+    logger.info("Protocol versions to sign requests: " + signVersions.toString());
+
+    return signVersions;
   }
 
   public boolean isV2OnlySignAuthenticate() {

--- a/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyConfig.java
+++ b/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyConfig.java
@@ -66,7 +66,7 @@ public class ProxyConfig {
   static public List<MAuthVersion> getSignVersions(String signVersionsStr) {
     List<MAuthVersion> signVersions = new ArrayList();
     List<String> unrecognizedVersions = new ArrayList();
-    List<String> versionList = Arrays.asList(signVersionsStr.trim().toLowerCase().split(","));
+    List<String> versionList = Arrays.asList(signVersionsStr.toLowerCase().split(","));
     versionList.forEach(e -> {
       switch (e.trim()) {
         case "v1":

--- a/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyServer.java
+++ b/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyServer.java
@@ -27,7 +27,7 @@ public class ProxyServer {
                 proxyConfig.getAppUuid(),
                 proxyConfig.getPrivateKey(),
                 new CurrentEpochTimeProvider(),
-                proxyConfig.isV2OnlySignRequests()
+                proxyConfig.getSignVersions()
         );
     }
 

--- a/modules/mauth-proxy/src/main/resources/reference.conf
+++ b/modules/mauth-proxy/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ app {
 }
 
 mauth {
-  v2_only_sign_requests: false
+  sign_versions: "v2" # default value
+  sign_versions: ${?MAUTH_SIGN_VERSIONS}
   v2_only_authenticate: false
 }

--- a/modules/mauth-proxy/src/test/resources/application.conf
+++ b/modules/mauth-proxy/src/test/resources/application.conf
@@ -7,3 +7,8 @@ app {
   uuid: ${?APP_MAUTH_UUID}
   private_key: ${?APP_MAUTH_PRIVATE_KEY}
 }
+
+mauth {
+  sign_versions: "v1,v2"
+  v2_only_authenticate: false
+}

--- a/modules/mauth-sender-sttp-akka-http/src/test/scala/com/mdsol/mauth/SttpAkkaMAuthRequestSenderSpec.scala
+++ b/modules/mauth-sender-sttp-akka-http/src/test/scala/com/mdsol/mauth/SttpAkkaMAuthRequestSenderSpec.scala
@@ -85,7 +85,7 @@ class SttpAkkaMAuthRequestSenderSpec extends AsyncWordSpec with BeforeAndAfter w
       UUID.fromString(APP_UUID_V2),
       getPrivateKeyFromString(TestFixtures.PRIVATE_KEY_2),
       epochTimeProvider,
-      false
+      SignerConfiguration.ALL_SIGN_VERSIONS
     )
   }
 

--- a/modules/mauth-signer-akka-http/README.adoc
+++ b/modules/mauth-signer-akka-http/README.adoc
@@ -7,8 +7,8 @@ This is an implementation of Medidata Authentication Client Signer to sign the H
 . Configuration
 
 ** MAuth uses https://github.com/typesafehub/config[Typesafe Config].
- Create `application.conf` on your classpath with following content. The v2_only_sign_requests flag can be set to sign outgoing requests with Mauth protocol V2 only, the default is false and the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
-+
+ Create `application.conf` on your classpath with the following content. The mauth_sign_requests option can be set to sign outgoing requests with Comma-separated protocol versions to sign requests. the default is v2. If the both v1 and v2 specified, the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
+
 ----
 app {
     uuid: "aaaa-bbbbb-ccccc-ddddd-eeeee"

--- a/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
+++ b/modules/mauth-signer-akka-http/src/main/scala/com/mdsol/mauth/MAuthRequestSigner.scala
@@ -2,10 +2,10 @@ package com.mdsol.mauth
 
 import java.net.URI
 import java.security.PrivateKey
-import java.util.UUID
-import scala.collection.JavaConverters._
-import models.{UnsignedRequest => NewUnsignedRequest, SignedRequest => NewSignedRequest}
+import java.util.{List, UUID}
 
+import scala.collection.JavaConverters._
+import models.{SignedRequest => NewSignedRequest, UnsignedRequest => NewUnsignedRequest}
 import com.mdsol.mauth.util.{CurrentEpochTimeProvider, EpochTimeProvider, MAuthKeysHelper}
 
 import scala.util.{Failure, Success, Try}
@@ -41,12 +41,12 @@ trait RequestSigner {
   def signRequest(request: NewUnsignedRequest): NewSignedRequest
 }
 
-class MAuthRequestSigner(appUUID: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider, v2OnlySignRequests: Boolean)
-    extends DefaultSigner(appUUID, privateKey, epochTimeProvider, v2OnlySignRequests)
+class MAuthRequestSigner(appUUID: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider, signVersions: List[MAuthVersion])
+    extends DefaultSigner(appUUID, privateKey, epochTimeProvider, signVersions)
     with RequestSigner {
 
   def this(appUUID: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider) =
-    this(appUUID, privateKey, epochTimeProvider, v2OnlySignRequests = false)
+    this(appUUID, privateKey, epochTimeProvider, SignerConfiguration.DEFAULT_SIGN_VERSION)
 
   def this(appUUID: UUID, privateKey: PrivateKey) = this(appUUID, privateKey, new CurrentEpochTimeProvider)
 
@@ -57,8 +57,8 @@ class MAuthRequestSigner(appUUID: UUID, privateKey: PrivateKey, epochTimeProvide
   def this(appUUID: UUID, privateKey: String, epochTimeProvider: EpochTimeProvider) =
     this(appUUID, MAuthKeysHelper.getPrivateKeyFromString(privateKey), epochTimeProvider)
 
-  def this(appUUID: UUID, privateKey: String, epochTimeProvider: EpochTimeProvider, v2OnlySignRequests: Boolean) =
-    this(appUUID, MAuthKeysHelper.getPrivateKeyFromString(privateKey), epochTimeProvider, v2OnlySignRequests)
+  def this(appUUID: UUID, privateKey: String, epochTimeProvider: EpochTimeProvider, signVersions: List[MAuthVersion]) =
+    this(appUUID, MAuthKeysHelper.getPrivateKeyFromString(privateKey), epochTimeProvider, signVersions)
 
   /**
     * Sign a request specification and return the desired header signatures
@@ -103,9 +103,9 @@ object MAuthRequestSigner {
   def apply(appUUID: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider): MAuthRequestSigner =
     new MAuthRequestSigner(appUUID, privateKey, epochTimeProvider)
 
-  def apply(appUUID: UUID, privateKey: String, epochTimeProvider: EpochTimeProvider, v2OnlySignRequests: Boolean): MAuthRequestSigner =
-    new MAuthRequestSigner(appUUID, privateKey, epochTimeProvider, v2OnlySignRequests)
+  def apply(appUUID: UUID, privateKey: String, epochTimeProvider: EpochTimeProvider, signVersions: List[MAuthVersion]): MAuthRequestSigner =
+    new MAuthRequestSigner(appUUID, privateKey, epochTimeProvider, signVersions)
 
-  def apply(appUUID: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider, v2OnlySignRequests: Boolean): MAuthRequestSigner =
-    new MAuthRequestSigner(appUUID, privateKey, epochTimeProvider, v2OnlySignRequests)
+  def apply(appUUID: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider, signVersions: List[MAuthVersion]): MAuthRequestSigner =
+    new MAuthRequestSigner(appUUID, privateKey, epochTimeProvider, signVersions)
 }

--- a/modules/mauth-signer-apachehttp/README.adoc
+++ b/modules/mauth-signer-apachehttp/README.adoc
@@ -5,8 +5,8 @@ This is an implementation of Medidata Authentication Client Signer to sign the H
 == Usage
 . Configuration
 * MAuth uses https://github.com/typesafehub/config[Typesafe Config].
- Create `application.conf` on your classpath with the following content. The v2_only_sign_requests flag can be set to sign outgoing requests with Mauth protocol V2 only, the default is false and the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
-+
+ Create `application.conf` on your classpath with the following content. The mauth_sign_requests option can be set to sign outgoing requests with Comma-separated protocol versions to sign requests. the default is v2. If the both v1 and v2 specified, the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
+
 ----
 app {
    uuid: "aaaa-bbbbb-ccccc-ddddd-eeeee"

--- a/modules/mauth-signer-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientRequestSigner.java
+++ b/modules/mauth-signer-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientRequestSigner.java
@@ -1,6 +1,7 @@
 package com.mdsol.mauth.apache;
 
 import com.mdsol.mauth.DefaultSigner;
+import com.mdsol.mauth.MAuthVersion;
 import com.mdsol.mauth.SignerConfiguration;
 import com.mdsol.mauth.exceptions.MAuthSigningException;
 import com.mdsol.mauth.util.CurrentEpochTimeProvider;
@@ -16,6 +17,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -41,8 +43,8 @@ public class HttpClientRequestSigner extends DefaultSigner {
     super(appUUID, privateKey, epochTimeProvider);
   }
 
-  public HttpClientRequestSigner(UUID appUUID, String privateKey, EpochTimeProvider epochTimeProvider, boolean v2OnlySignRequests) {
-    super(appUUID, privateKey, epochTimeProvider, v2OnlySignRequests);
+  public HttpClientRequestSigner(UUID appUUID, String privateKey, EpochTimeProvider epochTimeProvider, List<MAuthVersion> signVersions) {
+    super(appUUID, privateKey, epochTimeProvider, signVersions);
   }
 
   /**

--- a/modules/mauth-signer-sttp/src/main/scala/com/mdsol/mauth/MAuthSttpSigner.scala
+++ b/modules/mauth-signer-sttp/src/main/scala/com/mdsol/mauth/MAuthSttpSigner.scala
@@ -17,8 +17,8 @@ trait MAuthSttpSigner {
 /** Sign an sttp request by adding MAuth headers to the request */
 class MAuthSttpSignerImpl(signer: Signer) extends MAuthSttpSigner {
 
-  def this(appUuid: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider, v2OnlySignRequest: Boolean = false) = {
-    this(new DefaultSigner(appUuid, privateKey, epochTimeProvider, v2OnlySignRequest))
+  def this(appUuid: UUID, privateKey: PrivateKey, epochTimeProvider: EpochTimeProvider, signVersions: java.util.List[MAuthVersion]) = {
+    this(new DefaultSigner(appUuid, privateKey, epochTimeProvider, signVersions))
   }
 
   def signSttpRequest[T](request: Request[T, Nothing]): Request[T, Nothing] = {

--- a/modules/mauth-signer-sttp/src/test/scala/com/mdsol/mauth/MAuthSttpSignerSpec.scala
+++ b/modules/mauth-signer-sttp/src/test/scala/com/mdsol/mauth/MAuthSttpSignerSpec.scala
@@ -72,7 +72,7 @@ class MAuthSttpSignerSpec extends AnyWordSpec with Matchers {
           appUuid = UUID.fromString(APP_UUID_V2),
           privateKey = getPrivateKeyFromString(PRIVATE_KEY_2),
           epochTimeProvider = epochTimeProvider,
-          v2OnlySignRequest = true
+          signVersions = java.util.Arrays.asList(MAuthVersion.MWSV2)
         )
         val req = basicRequest.get(Uri(new URI(s"http://host.com$REQUEST_NORMALIZE_PATH"))).body("")
         val signedReq = signer.signSttpRequest(req)
@@ -83,6 +83,17 @@ class MAuthSttpSignerSpec extends AnyWordSpec with Matchers {
 
     }
 
+    "When v1 only is set" should {
+      "add v1 authentication and time header only to the request (no v2 headers)" in {
+        val signedReq = v1OnlySigner.signSttpRequest(emptyPathNoBodyReq)
+        signedReq.getV1TimeHeaderValue shouldBe Some(EXPECTED_TIME_HEADER_1)
+        signedReq.getV1AuthHeaderValue shouldBe Some(EXPECTED_AUTH_NO_BODY_V1)
+
+        signedReq.getV2TimeHeaderValue shouldBe None
+        signedReq.getV2AuthHeaderValue shouldBe None
+      }
+    }
+
   }
 
   lazy val CONST_EPOCH_TIME_PROVIDER: EpochTimeProvider = new EpochTimeProvider() { override def inSeconds(): Long = EXPECTED_TIME_HEADER_1.toLong }
@@ -91,14 +102,21 @@ class MAuthSttpSignerSpec extends AnyWordSpec with Matchers {
     appUuid = UUID.fromString(APP_UUID_1),
     privateKey = getPrivateKeyFromString(PRIVATE_KEY_1),
     epochTimeProvider = CONST_EPOCH_TIME_PROVIDER,
-    v2OnlySignRequest = false
+    signVersions = SignerConfiguration.ALL_SIGN_VERSIONS
   )
 
   lazy val v2OnlySigner = new MAuthSttpSignerImpl(
     appUuid = UUID.fromString(APP_UUID_1),
     privateKey = getPrivateKeyFromString(PRIVATE_KEY_1),
     epochTimeProvider = CONST_EPOCH_TIME_PROVIDER,
-    v2OnlySignRequest = true
+    signVersions = java.util.Arrays.asList(MAuthVersion.MWSV2)
+  )
+
+  lazy val v1OnlySigner = new MAuthSttpSignerImpl(
+    appUuid = UUID.fromString(APP_UUID_1),
+    privateKey = getPrivateKeyFromString(PRIVATE_KEY_1),
+    epochTimeProvider = CONST_EPOCH_TIME_PROVIDER,
+    signVersions = java.util.Arrays.asList(MAuthVersion.MWS)
   )
 
 }

--- a/modules/mauth-signer/src/main/java/com/mdsol/mauth/SignerConfiguration.java
+++ b/modules/mauth-signer/src/main/java/com/mdsol/mauth/SignerConfiguration.java
@@ -1,53 +1,91 @@
 package com.mdsol.mauth;
 
 import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 public class SignerConfiguration implements MAuthConfiguration {
+  private static final Logger logger = LoggerFactory.getLogger(SignerConfiguration.class);
+
   public static final String APP_SECTION_HEADER = "app";
   public static final String MAUTH_SECTION_HEADER = "mauth";
   public static final String APP_UUID_PATH = APP_SECTION_HEADER + ".uuid";
   public static final String APP_PRIVATE_KEY_PATH = APP_SECTION_HEADER + ".private_key";
-  public static final String V2_ONLY_SIGN_REQUESTS = MAUTH_SECTION_HEADER + ".v2_only_sign_requests";
+  public static final String MAUTH_SIGN_VERSIONS = MAUTH_SECTION_HEADER + ".sign_versions";
 
+  public static final List<MAuthVersion> ALL_SIGN_VERSIONS = Arrays.asList(MAuthVersion.values());
+  public static final List<MAuthVersion> DEFAULT_SIGN_VERSION = Arrays.asList(MAuthVersion.MWSV2);
 
   private final UUID appUUID;
   private final transient String privateKey;
-  private boolean v2OnlySignRequests = false;
+  private List<MAuthVersion> signVersions;
 
   public SignerConfiguration(Config config) {
     this( UUID.fromString(config.getString(APP_UUID_PATH)),
         config.getString(APP_PRIVATE_KEY_PATH),
-        config.hasPath(V2_ONLY_SIGN_REQUESTS) || config.isEmpty() ? config.getBoolean(V2_ONLY_SIGN_REQUESTS) : false);
+        config.hasPath(MAUTH_SIGN_VERSIONS) ? config.getString(MAUTH_SIGN_VERSIONS) : "");
   }
 
   public SignerConfiguration(UUID appUUID, String privateKey) {
+    this(appUUID, privateKey, DEFAULT_SIGN_VERSION);
+  }
+
+  public SignerConfiguration(UUID appUUID, String privateKey, String signVersionsStr) {
     validateNotNull(appUUID, "Application UUID");
     validateNotBlank(privateKey, "Application Private key");
-
     this.appUUID = appUUID;
     this.privateKey = privateKey;
+    this.signVersions = getSignVersions(signVersionsStr);
   }
 
-  public SignerConfiguration(UUID appUUID, String privateKey, boolean v2OnlySignRequests) {
+  public SignerConfiguration(UUID appUUID, String privateKey, List<MAuthVersion> signVersions) {
     validateNotNull(appUUID, "Application UUID");
     validateNotBlank(privateKey, "Application Private key");
-
     this.appUUID = appUUID;
     this.privateKey = privateKey;
-    this.v2OnlySignRequests = v2OnlySignRequests;
+    this.signVersions = signVersions;
   }
 
-  public UUID getAppUUID() {
-    return appUUID;
-  }
+  public UUID getAppUUID() { return appUUID; }
 
   public String getPrivateKey() {
     return privateKey;
   }
 
-  public boolean isV2OnlySignRequests() {
-    return v2OnlySignRequests;
+  public List<MAuthVersion> getSignVersions() {
+    return signVersions;
+  }
+
+  static public List<MAuthVersion> getSignVersions(String signVersionsStr) {
+    List<MAuthVersion> signVersions = new ArrayList();
+    List<String> unrecognizedVersions = new ArrayList();
+    List<String> versionList = Arrays.asList(signVersionsStr.trim().toLowerCase().split(","));
+    versionList.forEach(e -> {
+      switch (e.trim()) {
+        case "v1":
+          signVersions.add(MAuthVersion.MWS);
+          break;
+        case "v2":
+          signVersions.add(MAuthVersion.MWSV2);
+          break;
+        default:
+          unrecognizedVersions.add(e.trim());
+          break;
+      }
+    });
+
+    if (signVersions.isEmpty()) return DEFAULT_SIGN_VERSION;
+
+    if (!unrecognizedVersions.isEmpty())
+      logger.warn("unrecognized versions to sign requests: " + unrecognizedVersions.toString());
+
+    logger.info("Protocol versions to sign requests: " + signVersions.toString());
+
+    return signVersions;
   }
 }

--- a/modules/mauth-signer/src/main/java/com/mdsol/mauth/SignerConfiguration.java
+++ b/modules/mauth-signer/src/main/java/com/mdsol/mauth/SignerConfiguration.java
@@ -64,7 +64,7 @@ public class SignerConfiguration implements MAuthConfiguration {
   static public List<MAuthVersion> getSignVersions(String signVersionsStr) {
     List<MAuthVersion> signVersions = new ArrayList();
     List<String> unrecognizedVersions = new ArrayList();
-    List<String> versionList = Arrays.asList(signVersionsStr.trim().toLowerCase().split(","));
+    List<String> versionList = Arrays.asList(signVersionsStr.toLowerCase().split(","));
     versionList.forEach(e -> {
       switch (e.trim()) {
         case "v1":

--- a/modules/mauth-signer/src/main/resources/reference.conf
+++ b/modules/mauth-signer/src/main/resources/reference.conf
@@ -2,3 +2,7 @@ app {
   uuid: ${?APP_MAUTH_UUID}
   private_key: ${?APP_MAUTH_PRIVATE_KEY}
 }
+
+mauth {
+  sign_versions: ${?MAUTH_SIGN_VERSIONS}
+}

--- a/modules/mauth-signer/src/test/scala/com/mdsol/mauth/DefaultSignerSpec.scala
+++ b/modules/mauth-signer/src/test/scala/com/mdsol/mauth/DefaultSignerSpec.scala
@@ -2,6 +2,7 @@ package com.mdsol.mauth
 
 import java.security.Security
 import java.util.UUID
+import java.util.NoSuchElementException
 
 import com.mdsol.mauth.exceptions.MAuthKeyException
 import com.mdsol.mauth.test.utils.TestFixtures
@@ -11,7 +12,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
   private val TEST_EPOCH_TIME = 1424700000L
@@ -21,12 +22,12 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
   private val AUTHENTICATION_HEADER_PATTERN_V2: String = s"MWSV2 $testUUID:[^;]*;"
 
   private val mockEpochTimeProvider = mock[EpochTimeProvider]
-  private val mAuthRequestSigner = new DefaultSigner(testUUID, TestFixtures.PRIVATE_KEY_1, mockEpochTimeProvider)
-  private val mAuthRequestSignerV2 = new DefaultSigner(testUUID, TestFixtures.PRIVATE_KEY_1, mockEpochTimeProvider, true)
+  private val mAuthRequestSigner = new DefaultSigner(testUUID, TestFixtures.PRIVATE_KEY_1, mockEpochTimeProvider, SignerConfiguration.ALL_SIGN_VERSIONS)
+  private val mAuthRequestSignerV2 = new DefaultSigner(testUUID, TestFixtures.PRIVATE_KEY_1, mockEpochTimeProvider, java.util.Arrays.asList(MAuthVersion.MWSV2))
 
   Security.addProvider(new BouncyCastleProvider)
 
-  it should "constructor with invalid key string throws an exception" in {
+  "DefaultSigner" should "constructor with invalid key string throws an exception" in {
     val expectedException = intercept[MAuthKeyException] {
       new DefaultSigner(testUUID, "This is not a valid key", mockEpochTimeProvider)
     }
@@ -73,14 +74,39 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
     headers(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_POST_AUTHENTICATION_HEADER
   }
 
-  it should "generated headers includes time header with correct time for V2" in {
+  "When v1 only is set" should "add mauth headers to a request for V1 only" in {
+    val CLIENT_REQUEST_BINARY_APP_UUID = TestFixtures.APP_UUID_V2
+    val CLIENT_REQUEST_BINARY_EPOCH_TIME: Long = TestFixtures.EPOCH_TIME.toLong
+    val CLIENT_REQUEST_BINARY_PATH = TestFixtures.REQUEST_PATH_V2
+    val CLIENT_REQUEST_QUERY_PARAMETERS = TestFixtures.REQUEST_QUERY_PARAMETERS_V2
+    val uuid = UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID)
+    val mAuthSigner = new DefaultSigner(uuid, TestFixtures.PRIVATE_KEY_2, mockEpochTimeProvider, java.util.Arrays.asList(MAuthVersion.MWS))
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_EPOCH_TIME)
+    val EXPECTED_AUTHENTICATION_HEADER_V1: String = s"""MWS $CLIENT_REQUEST_BINARY_APP_UUID:${TestFixtures.SIGNATURE_V1_BINARY}"""
+    val headers: Map[String, String] =
+      mAuthSigner.generateRequestHeaders("PUT", CLIENT_REQUEST_BINARY_PATH, TestFixtures.BINARY_FILE_BODY, CLIENT_REQUEST_QUERY_PARAMETERS).asScala.toMap
+    headers.size shouldEqual 2
+    headers(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_AUTHENTICATION_HEADER_V1
+    headers(MAuthRequest.X_MWS_TIME_HEADER_NAME) shouldBe String.valueOf(CLIENT_REQUEST_BINARY_EPOCH_TIME)
+
+    val expectedException = intercept[NoSuchElementException] {
+      headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME)
+    }
+    expectedException.getMessage shouldBe "key not found: " + MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME
+  }
+
+  "When v2 only is set" should "generated headers includes time header with correct time for V2" in {
     //noinspection ConvertibleToMethodValue
     (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(TEST_EPOCH_TIME)
     val headers: Map[String, String] = mAuthRequestSignerV2.generateRequestHeaders("GET", "/", "".getBytes, "").asScala.toMap
     headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe String.valueOf(TEST_EPOCH_TIME)
+    val expectedException = intercept[NoSuchElementException] {
+      headers(MAuthRequest.X_MWS_TIME_HEADER_NAME)
+    }
+    expectedException.getMessage shouldBe "key not found: " + MAuthRequest.X_MWS_TIME_HEADER_NAME
   }
 
-  it should "generated headers with body includes expected authentication header for V2 only if V2 only enabled" in {
+  it should "generated headers with body includes expected authentication header for V2 only" in {
     //noinspection ConvertibleToMethodValue
     (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(TEST_EPOCH_TIME)
     val EXPECTED_POST_AUTHENTICATION_HEADER: String =
@@ -92,11 +118,13 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
          |tKVsZ29Qu3ZktDThdUeQnD4qt6LoGVkzru/ynJddeLinQB0m0ixjYRFiTr3
          |YOGg==;""".stripMargin.replaceAll("\n", "")
     val headers: Map[String, String] = mAuthRequestSignerV2.generateRequestHeaders("POST", "/", TEST_REQUEST_BODY.getBytes, "").asScala.toMap
+    headers.size shouldEqual 2
     headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) matches AUTHENTICATION_HEADER_PATTERN_V2
     headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_POST_AUTHENTICATION_HEADER
+    headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe String.valueOf(TEST_EPOCH_TIME)
   }
 
-  it should "generated headers with parameters includes expected authentication header for V2 only if V2 only enabled" in {
+  it should "generated headers with parameters includes expected authentication header for V2 only" in {
     //noinspection ConvertibleToMethodValue
     (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(TEST_EPOCH_TIME)
     val EXPECTED_GET_AUTHENTICATION_HEADER: String =
@@ -108,13 +136,19 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
          |Hqu5G+5/6DiTt4W2iTEkC9BUV/OObdNNbr72hN1Z5qHo/X8qZ7NMSRPyZPA
          |xe6A==;""".stripMargin.replaceAll("\n", "")
     val headers: Map[String, String] = mAuthRequestSignerV2.generateRequestHeaders("GET", "/", "".getBytes, TEST_REQUEST_PARAMS).asScala.toMap
+    headers.size shouldEqual 2
     headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) matches AUTHENTICATION_HEADER_PATTERN_V2
     headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) shouldBe EXPECTED_GET_AUTHENTICATION_HEADER
+
+    val expectedException = intercept[NoSuchElementException] {
+      headers(MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME)
+    }
+    expectedException.getMessage shouldBe "key not found: " + MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME
   }
 
-  it should "generated headers for both V1 and V2 if V2 only is disabled" in {
+  "When v1 and v2 are set" should "generated headers with body for both V1 and V2" in {
     //noinspection ConvertibleToMethodValue
-    val mAuthSigner = new DefaultSigner(testUUID, TestFixtures.PRIVATE_KEY_1, mockEpochTimeProvider, false)
+    val mAuthSigner = new DefaultSigner(testUUID, TestFixtures.PRIVATE_KEY_1, mockEpochTimeProvider, SignerConfiguration.ALL_SIGN_VERSIONS)
     (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(TEST_EPOCH_TIME)
     val EXPECTED_POST_AUTHENTICATION_HEADER_V1: String =
       s"""MWS $testUUID:aDItoM9IOknNhPKH9a
@@ -139,13 +173,15 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
     headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe String.valueOf(TEST_EPOCH_TIME)
   }
 
-  it should "generated headers for binary payload for both V1 and V2 if V2 only is disabled" in {
+  it should "generated headers for binary payload for both V1 and V2" in {
     //noinspection ConvertibleToMethodValue
     val CLIENT_REQUEST_BINARY_APP_UUID = TestFixtures.APP_UUID_V2
     val CLIENT_REQUEST_BINARY_EPOCH_TIME: Long = TestFixtures.EPOCH_TIME.toLong
     val CLIENT_REQUEST_BINARY_PATH = TestFixtures.REQUEST_PATH_V2
     val CLIENT_REQUEST_QUERY_PARAMETERS = TestFixtures.REQUEST_QUERY_PARAMETERS_V2
-    val mAuthSigner = new DefaultSigner(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID), TestFixtures.PRIVATE_KEY_2, mockEpochTimeProvider, false)
+    val uuid = UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID)
+    val mAuthSigner = new DefaultSigner(uuid, TestFixtures.PRIVATE_KEY_2, mockEpochTimeProvider, SignerConfiguration.ALL_SIGN_VERSIONS)
+
     (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_EPOCH_TIME)
     val EXPECTED_AUTHENTICATION_HEADER_V1: String = s"""MWS $CLIENT_REQUEST_BINARY_APP_UUID:${TestFixtures.SIGNATURE_V1_BINARY}"""
     val EXPECTED_AUTHENTICATION_HEADER_V2: String = s"""MWSV2 $CLIENT_REQUEST_BINARY_APP_UUID:${TestFixtures.SIGNATURE_V2_BINARY};"""
@@ -157,4 +193,22 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
     headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe String.valueOf(CLIENT_REQUEST_BINARY_EPOCH_TIME)
   }
 
+  "SignerConfiguration" should "correctly get sign versions" in {
+    val expected_sign_versions = SignerConfiguration.ALL_SIGN_VERSIONS
+    var signerConfig = new SignerConfiguration(testUUID, TestFixtures.PRIVATE_KEY_1, "v1,v2")
+    signerConfig.getSignVersions shouldBe expected_sign_versions
+    signerConfig = new SignerConfiguration(testUUID, TestFixtures.PRIVATE_KEY_1, " V1 , V2 ")
+    signerConfig.getSignVersions shouldBe expected_sign_versions
+  }
+
+  it should "get the supported sign versions only" in {
+    val signerConfig = new SignerConfiguration(testUUID, TestFixtures.PRIVATE_KEY_1, "dummy, v2, v20")
+    signerConfig.getSignVersions shouldBe java.util.Arrays.asList(MAuthVersion.MWSV2)
+
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(TEST_EPOCH_TIME)
+    val mAuthSigner = new DefaultSigner(signerConfig.getAppUUID, signerConfig.getPrivateKey, mockEpochTimeProvider, signerConfig.getSignVersions)
+    val headers: Map[String, String] = mAuthSigner.generateRequestHeaders("GET", "/", "".getBytes, "").asScala.toMap
+    headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) matches AUTHENTICATION_HEADER_PATTERN_V2
+    headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe String.valueOf(TEST_EPOCH_TIME)
+  }
 }


### PR DESCRIPTION
This PR includes the changes:
1. replace `V2_ONLY_SIGN_REQUESTS` option with `MAUTH_SIGN_VERSIONS` option;
2. change the default to `v2` only for the signing protocol version;

**Notes:**
Since not all apps are updated to the latest, please use v1 when you experience authentication failures.
Ruby: https://github.com/mdsol/mauth-client-ruby/pull/40
Python: https://github.com/mdsol/mauth-client-python/pull/19

@jatcwang @austek @mdsol/architecture-enablement