### PR TITLE
[MCC-650302] Change the default signing versions to v1 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change the default signing versions to 'v1' only
 
 ## [5.0.0] - 2020-07-14
 ### Changed

--- a/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyConfig.java
+++ b/modules/mauth-proxy/src/main/java/com/mdsol/mauth/proxy/ProxyConfig.java
@@ -66,22 +66,25 @@ public class ProxyConfig {
   static public List<MAuthVersion> getSignVersions(String signVersionsStr) {
     List<MAuthVersion> signVersions = new ArrayList();
     List<String> unrecognizedVersions = new ArrayList();
-    List<String> versionList = Arrays.asList(signVersionsStr.toLowerCase().split(","));
-    versionList.forEach(e -> {
-      switch (e.trim()) {
-        case "v1":
-          signVersions.add(MAuthVersion.MWS);
-          break;
-        case "v2":
-          signVersions.add(MAuthVersion.MWSV2);
-          break;
-        default:
-          unrecognizedVersions.add(e.trim());
-          break;
-      }
-    });
+    if (signVersionsStr != null) {
+      List<String> versionList = Arrays.asList(signVersionsStr.toLowerCase().split(","));
+      versionList.forEach(e -> {
+        switch (e.trim()) {
+          case "v1":
+            signVersions.add(MAuthVersion.MWS);
+            break;
+          case "v2":
+            signVersions.add(MAuthVersion.MWSV2);
+            break;
+          default:
+            unrecognizedVersions.add(e.trim());
+            break;
+        }
+      });
+    }
+
     if (signVersions.isEmpty())
-      signVersions.add(MAuthVersion.MWSV2);
+      signVersions.add(MAuthVersion.MWS);
 
     if (!unrecognizedVersions.isEmpty())
       logger.warn("unrecognized versions to sign requests: " + unrecognizedVersions.toString());

--- a/modules/mauth-proxy/src/main/resources/reference.conf
+++ b/modules/mauth-proxy/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ app {
 }
 
 mauth {
-  sign_versions: "v2" # default value
+  sign_versions: "v1" # default value
   sign_versions: ${?MAUTH_SIGN_VERSIONS}
   v2_only_authenticate: false
 }

--- a/modules/mauth-signer-akka-http/README.adoc
+++ b/modules/mauth-signer-akka-http/README.adoc
@@ -7,7 +7,7 @@ This is an implementation of Medidata Authentication Client Signer to sign the H
 . Configuration
 
 ** MAuth uses https://github.com/typesafehub/config[Typesafe Config].
- Create `application.conf` on your classpath with the following content. The mauth_sign_requests option can be set to sign outgoing requests with Comma-separated protocol versions to sign requests. the default is v2. If the both v1 and v2 specified, the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
+ Create `application.conf` on your classpath with the following content. The mauth_sign_requests option can be set to sign outgoing requests with Comma-separated protocol versions to sign requests. the default is v1. If the both v1 and v2 specified, the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
 
 ----
 app {

--- a/modules/mauth-signer-apachehttp/README.adoc
+++ b/modules/mauth-signer-apachehttp/README.adoc
@@ -5,7 +5,7 @@ This is an implementation of Medidata Authentication Client Signer to sign the H
 == Usage
 . Configuration
 * MAuth uses https://github.com/typesafehub/config[Typesafe Config].
- Create `application.conf` on your classpath with the following content. The mauth_sign_requests option can be set to sign outgoing requests with Comma-separated protocol versions to sign requests. the default is v2. If the both v1 and v2 specified, the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
+ Create `application.conf` on your classpath with the following content. The mauth_sign_requests option can be set to sign outgoing requests with Comma-separated protocol versions to sign requests. the default is v1. If the both v1 and v2 specified, the client sign requests with both x-mws-xxxxx and mcc-xxxxx headers
 
 ----
 app {

--- a/modules/mauth-signer/src/main/java/com/mdsol/mauth/SignerConfiguration.java
+++ b/modules/mauth-signer/src/main/java/com/mdsol/mauth/SignerConfiguration.java
@@ -19,7 +19,7 @@ public class SignerConfiguration implements MAuthConfiguration {
   public static final String MAUTH_SIGN_VERSIONS = MAUTH_SECTION_HEADER + ".sign_versions";
 
   public static final List<MAuthVersion> ALL_SIGN_VERSIONS = Arrays.asList(MAuthVersion.values());
-  public static final List<MAuthVersion> DEFAULT_SIGN_VERSION = Arrays.asList(MAuthVersion.MWSV2);
+  public static final List<MAuthVersion> DEFAULT_SIGN_VERSION = Arrays.asList(MAuthVersion.MWS);
 
   private final UUID appUUID;
   private final transient String privateKey;
@@ -64,24 +64,26 @@ public class SignerConfiguration implements MAuthConfiguration {
   static public List<MAuthVersion> getSignVersions(String signVersionsStr) {
     List<MAuthVersion> signVersions = new ArrayList();
     List<String> unrecognizedVersions = new ArrayList();
-    List<String> versionList = Arrays.asList(signVersionsStr.toLowerCase().split(","));
-    versionList.forEach(e -> {
-      switch (e.trim()) {
-        case "v1":
-          signVersions.add(MAuthVersion.MWS);
-          break;
-        case "v2":
-          signVersions.add(MAuthVersion.MWSV2);
-          break;
-        default:
-          unrecognizedVersions.add(e.trim());
-          break;
-      }
-    });
+    if (signVersionsStr != null) {
+      List<String> versionList = Arrays.asList(signVersionsStr.toLowerCase().split(","));
+      versionList.forEach(e -> {
+        switch (e.trim()) {
+          case "v1":
+            signVersions.add(MAuthVersion.MWS);
+            break;
+          case "v2":
+            signVersions.add(MAuthVersion.MWSV2);
+            break;
+          default:
+            unrecognizedVersions.add(e.trim());
+            break;
+        }
+      });
+    }
 
-    if (signVersions.isEmpty()) return DEFAULT_SIGN_VERSION;
+    if (signVersions.isEmpty()) signVersions.addAll(DEFAULT_SIGN_VERSION);
 
-    if (!unrecognizedVersions.isEmpty())
+    if (unrecognizedVersions.size() > 0)
       logger.warn("unrecognized versions to sign requests: " + unrecognizedVersions.toString());
 
     logger.info("Protocol versions to sign requests: " + signVersions.toString());

--- a/modules/mauth-signer/src/test/scala/com/mdsol/mauth/DefaultSignerSpec.scala
+++ b/modules/mauth-signer/src/test/scala/com/mdsol/mauth/DefaultSignerSpec.scala
@@ -211,4 +211,12 @@ class DefaultSignerSpec extends AnyFlatSpec with Matchers with MockFactory {
     headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) matches AUTHENTICATION_HEADER_PATTERN_V2
     headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe String.valueOf(TEST_EPOCH_TIME)
   }
+
+  it should "be default sign version" in {
+    val expected_sign_versions = SignerConfiguration.DEFAULT_SIGN_VERSION
+    SignerConfiguration.getSignVersions(null) shouldBe expected_sign_versions
+    SignerConfiguration.getSignVersions("") shouldBe expected_sign_versions
+    SignerConfiguration.getSignVersions("v10, v20, v30") shouldBe expected_sign_versions
+  }
+
 }


### PR DESCRIPTION
This PR changed the default signing versions to 'v1' only. 

**Background**
https://github.com/mdsol/mauth-client-dotnet/pull/63#discussion_r460095452

Out of caution I was going to say we sign with V1 and V2 (or even just V1) by default. I do like the idea of "well behaved" implementations not having to do anything to "turn v2 on" later but I think I'd rather have planned config changes later than risk having some requests failing as inauthentic in production and scrambling to change config. It's likely that we would catch such failures in lower environments and be able to adjust signing config appropriately but it's not certain.

The other language updates: https://github.com/mdsol/mauth-client-python/pull/23

@mdsol/architecture-enablement @austek @jatcwang @cmcinnes-mdsol @jcarres-mdsol 