### PR TITLE
[MCC-693298]Accept request payload as InputStream for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Accept request payload as java.io.InputStream for Java
 
 ## [5.0.2] - 2020-11-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Accept request payload as java.io.InputStream for Java
+- Accept request payload as java.io.InputStream for Java. Since InputStream in general can only be consumed once, here are limitations of using stream payload:
+  - mauth-signer generates the signature for v2 only even the both v1 and v2 are required.
+  - mauth-authenticator doesn't support "Fall back to V1 authentication when V2 authentication fails".
 
 ## [5.0.2] - 2020-11-05
 ### Changed

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -61,8 +61,9 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
   }
 
   private PublicKey getPublicKeyFromEureka(UUID appUUID) {
+    byte[] payload = new byte[0];
     String requestUrlPath = getRequestUrlPath(appUUID);
-    Map<String, String> headers = signer.generateRequestHeaders("GET", requestUrlPath, null, "");
+    Map<String, String> headers = signer.generateRequestHeaders("GET", requestUrlPath, payload, "");
     String requestUrl = configuration.getBaseUrl() + requestUrlPath;
     String publicKeyAsString = get(requestUrl, headers, publicKeyResponseHandler);
     return MAuthKeysHelper.getPublicKeyFromString(publicKeyAsString);

--- a/modules/mauth-authenticator-apachehttp/src/test/scala/com/mdsol/mauth/apache/HttpClientPublicKeyProviderSpec.scala
+++ b/modules/mauth-authenticator-apachehttp/src/test/scala/com/mdsol/mauth/apache/HttpClientPublicKeyProviderSpec.scala
@@ -46,7 +46,7 @@ class HttpClientPublicKeyProviderSpec extends AnyFlatSpec with Matchers with Moc
     mockedHeaders.put(X_MWS_TIME_HEADER_NAME, EXPECTED_TIME_HEADER_VALUE)
     mockedHeaders.put(MCC_AUTHENTICATION_HEADER_NAME, EXPECTED_AUTHENTICATION_HEADER_VALUE_V2)
     mockedHeaders.put(MCC_TIME_HEADER_NAME, EXPECTED_TIME_HEADER_VALUE)
-    (mockedSigner.generateRequestHeaders(_: String, _: String, _: Array[Byte], _: String)).expects("GET", *, null, "").returns(mockedHeaders)
+    (mockedSigner.generateRequestHeaders(_: String, _: String, _: Array[Byte], _: String)).expects("GET", *, *, "").returns(mockedHeaders)
     new HttpClientPublicKeyProvider(configuration, mockedSigner)
   }
 

--- a/modules/mauth-authenticator-scala/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
+++ b/modules/mauth-authenticator-scala/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
@@ -58,8 +58,6 @@ class RequestAuthenticator(publicKeyProvider: ClientPublicKeyProvider, epochTime
                   v2IsValidated
                 else if (v2IsValidated)
                   v2IsValidated
-                else if (mAuthRequest.getInputStream != null)
-                  v2IsValidated
                 else
                   fallbackValidateSignatureV1(mAuthRequest, clientPublicKey)
             }
@@ -129,7 +127,6 @@ class RequestAuthenticator(publicKeyProvider: ClientPublicKeyProvider, epochTime
         mAuthRequest.getResourcePath,
         mAuthRequest.getQueryParameters
       )
-      mAuthRequestV1.setInputStream(mAuthRequest.getInputStream)
       isValidated = validateSignatureV1(mAuthRequestV1, clientPublicKey)
       if (isValidated) {
         logger.warn("Completed successful authentication attempt after fallback to V1")

--- a/modules/mauth-authenticator-scala/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
+++ b/modules/mauth-authenticator-scala/src/main/scala/com/mdsol/mauth/scaladsl/RequestAuthenticator.scala
@@ -118,7 +118,9 @@ class RequestAuthenticator(publicKeyProvider: ClientPublicKeyProvider, epochTime
 
   private def fallbackValidateSignatureV1(mAuthRequest: MAuthRequest, clientPublicKey: PublicKey) = {
     var isValidated = false
-    if (mAuthRequest.getXmwsSignature != null && mAuthRequest.getXmwsTime != null) {
+    if (mAuthRequest.getMessagePayload == null) {
+      logger.warn("V1 authentication fallback is not available because the full request body is not available in memory.")
+    } else if (mAuthRequest.getXmwsSignature != null && mAuthRequest.getXmwsTime != null) {
       val mAuthRequestV1 = new MAuthRequest(
         mAuthRequest.getXmwsSignature,
         mAuthRequest.getMessagePayload,

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
@@ -193,7 +193,7 @@ trait RequestAuthenticatorBaseSpec extends AnyFlatSpec with BeforeAndAfterAll wi
       .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V1)
       .withTimeHeaderValue(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE)
       .withHttpMethod(TestFixtures.REQUEST_METHOD_V2)
-      .withInputStream(new java.io.ByteArrayInputStream(TestFixtures.BINARY_FILE_BODY))
+      .withBodyInputStream(new java.io.ByteArrayInputStream(TestFixtures.BINARY_FILE_BODY))
       .withResourcePath(TestFixtures.REQUEST_PATH_V2)
       .withQueryParameters(TestFixtures.REQUEST_QUERY_PARAMETERS_V2)
       .build
@@ -204,7 +204,7 @@ trait RequestAuthenticatorBaseSpec extends AnyFlatSpec with BeforeAndAfterAll wi
       .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V2)
       .withTimeHeaderValue(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE)
       .withHttpMethod(TestFixtures.REQUEST_METHOD_V2)
-      .withInputStream(new java.io.ByteArrayInputStream(TestFixtures.BINARY_FILE_BODY))
+      .withBodyInputStream(new java.io.ByteArrayInputStream(TestFixtures.BINARY_FILE_BODY))
       .withResourcePath(TestFixtures.REQUEST_PATH_V2)
       .withQueryParameters(TestFixtures.REQUEST_QUERY_PARAMETERS_V2)
       .build
@@ -214,7 +214,7 @@ trait RequestAuthenticatorBaseSpec extends AnyFlatSpec with BeforeAndAfterAll wi
     MAuthRequest.Builder.get
       .withHttpMethod(CLIENT_REQUEST_METHOD)
       .withMauthHeaders(CLIENT_REQUEST_HEADERS2)
-      .withInputStream(new java.io.ByteArrayInputStream(CLIENT_REQUEST_BODY.getBytes(StandardCharsets.UTF_8)))
+      .withBodyInputStream(new java.io.ByteArrayInputStream(CLIENT_REQUEST_BODY.getBytes(StandardCharsets.UTF_8)))
       .withResourcePath(CLIENT_REQUEST_PATH)
       .withQueryParameters("")
       .build

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorBaseSpec.scala
@@ -188,4 +188,36 @@ trait RequestAuthenticatorBaseSpec extends AnyFlatSpec with BeforeAndAfterAll wi
       .build
   }
 
+  def getRequestWithStreamBodyV1: MAuthRequest = {
+    MAuthRequest.Builder.get
+      .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V1)
+      .withTimeHeaderValue(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE)
+      .withHttpMethod(TestFixtures.REQUEST_METHOD_V2)
+      .withInputStream(new java.io.ByteArrayInputStream(TestFixtures.BINARY_FILE_BODY))
+      .withResourcePath(TestFixtures.REQUEST_PATH_V2)
+      .withQueryParameters(TestFixtures.REQUEST_QUERY_PARAMETERS_V2)
+      .build
+  }
+
+  def getRequestWithStreamBodyV2: MAuthRequest = {
+    MAuthRequest.Builder.get
+      .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_BINARY_HEADER_V2)
+      .withTimeHeaderValue(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE)
+      .withHttpMethod(TestFixtures.REQUEST_METHOD_V2)
+      .withInputStream(new java.io.ByteArrayInputStream(TestFixtures.BINARY_FILE_BODY))
+      .withResourcePath(TestFixtures.REQUEST_PATH_V2)
+      .withQueryParameters(TestFixtures.REQUEST_QUERY_PARAMETERS_V2)
+      .build
+  }
+
+  def getRequestWithStreamBodyAndWrongV2Signature: MAuthRequest = {
+    MAuthRequest.Builder.get
+      .withHttpMethod(CLIENT_REQUEST_METHOD)
+      .withMauthHeaders(CLIENT_REQUEST_HEADERS2)
+      .withInputStream(new java.io.ByteArrayInputStream(CLIENT_REQUEST_BODY.getBytes(StandardCharsets.UTF_8)))
+      .withResourcePath(CLIENT_REQUEST_PATH)
+      .withQueryParameters("")
+      .build
+  }
+
 }

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/RequestAuthenticatorSpec.scala
@@ -121,4 +121,29 @@ class RequestAuthenticatorSpec extends AnyFlatSpec with RequestAuthenticatorBase
     authenticatorV2.authenticate(getRequestWithWrongV2Signature) shouldBe false
   }
 
+  "When payload is inputstream" should "authenticate a valid request for V1" in {
+    //noinspection ConvertibleToMethodValue
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE.toLong + 3)
+    (mockClientPublicKeyProvider.getPublicKey _)
+      .expects(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID))
+      .returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY2))
+    authenticator.authenticate(getRequestWithStreamBodyV1) shouldBe true
+  }
+
+  it should "authenticate a valid request for V2" in {
+    //noinspection ConvertibleToMethodValue
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_REQUEST_BINARY_TIME_HEADER_VALUE.toLong + 5)
+    (mockClientPublicKeyProvider.getPublicKey _)
+      .expects(UUID.fromString(CLIENT_REQUEST_BINARY_APP_UUID))
+      .returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY2))
+    authenticator.authenticate(getRequestWithStreamBodyV2) shouldBe true
+  }
+
+  it should "fail validating request with validated V1 headers and wrong V2 signature" in {
+    //noinspection ConvertibleToMethodValue
+    (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(CLIENT_MCC_TIME_HEADER_VALUE.toLong + 3)
+    (mockClientPublicKeyProvider.getPublicKey _).expects(EXISTING_CLIENT_APP_UUID).returns(MAuthKeysHelper.getPublicKeyFromString(PUBLIC_KEY))
+    authenticator.authenticate(getRequestWithStreamBodyAndWrongV2Signature) shouldBe false
+  }
+
 }

--- a/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
+++ b/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
@@ -114,8 +114,6 @@ public class RequestAuthenticator implements Authenticator {
         return v2IsValidated;
       } else if (v2IsValidated) {
         return v2IsValidated;
-      } else if (mAuthRequest.getInputStream() != null) {
-        return v2IsValidated;
       } else {
         return fallbackValidateSignatureV1(mAuthRequest, clientPublicKey);
       }
@@ -180,7 +178,6 @@ public class RequestAuthenticator implements Authenticator {
           mAuthRequest.getResourcePath(),
           mAuthRequest.getQueryParameters()
       );
-      mAuthRequestV1.setInputStream(mAuthRequest.getInputStream());
       isValidated = validateSignatureV1(mAuthRequestV1, clientPublicKey);
       if (isValidated) {
         logger.warn("Completed successful authentication attempt after fallback to V1");

--- a/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
+++ b/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java
@@ -169,7 +169,9 @@ public class RequestAuthenticator implements Authenticator {
 
   private boolean fallbackValidateSignatureV1(MAuthRequest mAuthRequest, PublicKey clientPublicKey) {
     boolean isValidated = false;
-    if (mAuthRequest.getXmwsSignature() != null && mAuthRequest.getXmwsTime() != null) {
+    if (mAuthRequest.getMessagePayload() == null) {
+      logger.warn("V1 authentication fallback is not available because the full request body is not available in memory.");
+    } else if (mAuthRequest.getXmwsSignature() != null && mAuthRequest.getXmwsTime() != null) {
       MAuthRequest mAuthRequestV1 = new MAuthRequest(
           mAuthRequest.getXmwsSignature(),
           mAuthRequest.getMessagePayload(),

--- a/modules/mauth-common/src/main/java/com/mdsol/mauth/MAuthRequest.java
+++ b/modules/mauth-common/src/main/java/com/mdsol/mauth/MAuthRequest.java
@@ -4,6 +4,7 @@ import com.mdsol.mauth.util.MAuthHeadersHelper;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
@@ -40,6 +41,7 @@ public class MAuthRequest {
   private final MAuthVersion mauthVersion;
   private String xmwsSignature = null;
   private String xmwsTime = null;
+  private InputStream inputStream = null;
 
   /**
    * Create a Mauth request
@@ -150,6 +152,14 @@ public class MAuthRequest {
     return mauthVersion;
   }
 
+  public void setInputStream(InputStream inputStream) {
+    this.inputStream = inputStream;
+  }
+
+  public InputStream getInputStream() {
+    return inputStream;
+  }
+
   private void validateNotBlank(String field, String fieldNameInExceptionMessage) {
     if (StringUtils.isBlank(field)) {
       throw new IllegalArgumentException(
@@ -172,6 +182,7 @@ public class MAuthRequest {
     private String resourcePath;
     private String queryParameters;
     private TreeMap<String, String> mauthHeaders = new TreeMap<String,String>(String.CASE_INSENSITIVE_ORDER);
+    private InputStream inputStream = null;
 
     public static Builder get() {
       return new Builder();
@@ -204,6 +215,11 @@ public class MAuthRequest {
 
     public Builder withQueryParameters(String queryParameters) {
       this.queryParameters = queryParameters;
+      return this;
+    }
+
+    public Builder withInputStream(InputStream inputStream) {
+      this.inputStream = inputStream;
       return this;
     }
 
@@ -241,6 +257,7 @@ public class MAuthRequest {
 
       MAuthRequest mAuthRequest = new MAuthRequest(authenticationHeaderValue, messagePayload,
           httpMethod, timeHeaderValue, resourcePath, queryParameters);
+      mAuthRequest.setInputStream(inputStream);
 
       if (mAuthRequest.getMauthVersion().equals(MAuthVersion.MWSV2)) {
         mAuthRequest.setXmwsSignature(mauthHeaders.get(X_MWS_AUTHENTICATION_HEADER_NAME));

--- a/modules/mauth-common/src/main/java/com/mdsol/mauth/MAuthRequest.java
+++ b/modules/mauth-common/src/main/java/com/mdsol/mauth/MAuthRequest.java
@@ -133,7 +133,15 @@ public class MAuthRequest {
 
     // we always use inputStream for Auth,
     // wrap byte array in ByteArrayInputStream if bodyInputStream wasn't provided explicitly
-    validatePayload(messagePayload, bodyInputStream);
+    if (bodyInputStream != null && messagePayload != null) {
+      throw new IllegalArgumentException("Only one of bodyInputStream and messagePayload should be provided.");
+    }
+
+    if (messagePayload == null && bodyInputStream == null) {
+      // Set payload to empty byte[]
+      messagePayload = new byte[] {};
+    }
+
     if (messagePayload != null) {
       // Use our body bytes as inputStream
       this.messagePayload = messagePayload;
@@ -195,10 +203,6 @@ public class MAuthRequest {
     return mauthVersion;
   }
 
-  public void setBodyInputStream(InputStream bodyInputStream) {
-    this.bodyInputStream = bodyInputStream;
-  }
-
   public InputStream getBodyInputStream() {
     return bodyInputStream;
   }
@@ -213,12 +217,6 @@ public class MAuthRequest {
   private void validateRequestTime(long requestTime) {
     if (requestTime <= 0) {
       throw new IllegalArgumentException("Request time cannot be negative or 0.");
-    }
-  }
-
-  private void validatePayload(byte[] messagePayload, InputStream bodyInputStream) {
-    if (bodyInputStream != null && messagePayload != null) {
-      throw new IllegalArgumentException("Only one of bodyInputStream and messagePayload should be provided.");
     }
   }
 
@@ -302,10 +300,6 @@ public class MAuthRequest {
           authenticationHeaderValue = mauthHeaders.get(X_MWS_AUTHENTICATION_HEADER_NAME);
           timeHeaderValue = mauthHeaders.get(X_MWS_TIME_HEADER_NAME);
         }
-      }
-
-      if (messagePayload == null && bodyInputStream == null) {
-        messagePayload = new byte[] {};
       }
 
       MAuthRequest mAuthRequest = new MAuthRequest(authenticationHeaderValue, messagePayload,

--- a/modules/mauth-common/src/main/java/com/mdsol/mauth/util/MAuthSignatureHelper.java
+++ b/modules/mauth-common/src/main/java/com/mdsol/mauth/util/MAuthSignatureHelper.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -93,20 +92,9 @@ public class MAuthSignatureHelper {
   @Deprecated
   public static String generateDigestedMessageV1(MAuthRequest mAuthRequest) throws IOException {
     logger.debug("Digest unencryptedSignature for V1");
-    String messageDigest;
-    if (mAuthRequest.getInputStream() == null) {
-      byte[]  messageDigest_bytes = MAuthSignatureHelper.generateUnencryptedSignature(
-          mAuthRequest.getAppUUID(), mAuthRequest.getHttpMethod(), mAuthRequest.getResourcePath(),
-          mAuthRequest.getMessagePayload(),
-          String.valueOf(mAuthRequest.getRequestTime())
-      );
-      messageDigest = MAuthSignatureHelper.getHexEncodedDigestedString(messageDigest_bytes);
-    } else {
-      SequenceInputStream stream = createSequenceInputStreamV1(mAuthRequest.getAppUUID(), mAuthRequest.getHttpMethod(),
-          mAuthRequest.getResourcePath(), mAuthRequest.getInputStream(), String.valueOf(mAuthRequest.getRequestTime()));
-      messageDigest = MAuthSignatureHelper.getHexEncodedDigestedString(stream);;
-    }
-    return messageDigest;
+    SequenceInputStream stream = createSequenceInputStreamV1(mAuthRequest.getAppUUID(), mAuthRequest.getHttpMethod(),
+          mAuthRequest.getResourcePath(), mAuthRequest.getBodyInputStream(), String.valueOf(mAuthRequest.getRequestTime()));
+    return MAuthSignatureHelper.getHexEncodedDigestedString(stream);
   }
 
   @Deprecated
@@ -170,12 +158,7 @@ public class MAuthSignatureHelper {
   public static String generateStringToSignV2(MAuthRequest mAuthRequest) throws MAuthSigningException{
     logger.debug("Generating String to sign for V2");
     String epochTime = String.valueOf(mAuthRequest.getRequestTime());
-    String bodyDigest;
-    if (mAuthRequest.getInputStream() != null) {
-      bodyDigest = getHexEncodedDigestedString(mAuthRequest.getInputStream());
-    } else {
-      bodyDigest = getHexEncodedDigestedString(mAuthRequest.getMessagePayload());
-    }
+    String bodyDigest = getHexEncodedDigestedString(mAuthRequest.getBodyInputStream());
     return stringToSignV2(mAuthRequest.getAppUUID(), mAuthRequest.getHttpMethod(),
         mAuthRequest.getResourcePath(), mAuthRequest.getQueryParameters(), bodyDigest, epochTime);
    }

--- a/modules/mauth-common/src/main/java/com/mdsol/mauth/util/MAuthSignatureHelper.java
+++ b/modules/mauth-common/src/main/java/com/mdsol/mauth/util/MAuthSignatureHelper.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -113,8 +114,8 @@ public class MAuthSignatureHelper {
     String part1 = httpMethod + "\n" + resourceUrl + "\n";
     InputStream part2 = requestBody;
     String part3 = "\n" + appUUID.toString() + "\n" + epochTime;
-    SequenceInputStream stream = new SequenceInputStream(new ByteArrayInputStream(part1.getBytes(StandardCharsets.UTF_8)),
-        new SequenceInputStream(part2, new ByteArrayInputStream(part3.getBytes(StandardCharsets.UTF_8))));
+    SequenceInputStream stream = new SequenceInputStream(new ByteArrayInputStream(part1.getBytes(StandardCharsets.ISO_8859_1)),
+        new SequenceInputStream(part2, new ByteArrayInputStream(part3.getBytes(StandardCharsets.ISO_8859_1))));
     return stream;
   }
 

--- a/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthRequestSpec.scala
+++ b/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthRequestSpec.scala
@@ -282,4 +282,19 @@ class MAuthRequestSpec extends AnyFlatSpec with Matchers {
     request.getMauthVersion shouldBe MAuthVersion.MWSV2
   }
 
+  it should "not allow to both messagePayload and bodyInputStream are not null" in {
+    val expectedException = intercept[IllegalArgumentException] {
+      MAuthRequest.Builder
+        .get()
+        .withHttpMethod(CLIENT_REQUEST_METHOD)
+        .withAuthenticationHeaderValue(CLIENT_REQUEST_AUTHENTICATION_HEADER)
+        .withTimeHeaderValue(CLIENT_REQUEST_TIME_HEADER)
+        .withMessagePayload(CLIENT_REQUEST_PAYLOAD)
+        .withBodyInputStream(new java.io.ByteArrayInputStream(CLIENT_REQUEST_PAYLOAD))
+        .withResourcePath(CLIENT_REQUEST_PATH)
+        .build()
+    }
+    expectedException.getMessage shouldBe "Only one of bodyInputStream and messagePayload should be provided."
+  }
+
 }

--- a/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthSignatureHelperSpec.scala
+++ b/modules/mauth-common/src/test/scala/com/mdsol/mauth/MAuthSignatureHelperSpec.scala
@@ -158,7 +158,7 @@ class MAuthSignatureHelperSpec extends AnyFlatSpec with Matchers {
       CLIENT_REQUEST_METHOD_V2,
       CLIENT_REQUEST_PATH_V2,
       CLIENT_REQUEST_QUERY_PARAMETERS_V2,
-      Array.empty,
+      Array[Byte](),
       TEST_EPOCH_TIME_V2
     )
     MAuthSignatureHelper.encryptSignatureRSA(TEST_PRIVATE_KEY, testString) shouldBe TestFixtures.SIGNATURE_V2_EMPTY

--- a/modules/mauth-signer/src/main/java/com/mdsol/mauth/Signer.java
+++ b/modules/mauth-signer/src/main/java/com/mdsol/mauth/Signer.java
@@ -2,6 +2,7 @@ package com.mdsol.mauth;
 
 import com.mdsol.mauth.exceptions.MAuthSigningException;
 
+import java.io.InputStream;
 import java.util.Map;
 
 public interface Signer {
@@ -41,4 +42,19 @@ public interface Signer {
   Map<String, String> generateRequestHeaders(String httpVerb,
       String requestPath, byte[] requestPayload, String queryParameters) throws MAuthSigningException;
 
+  /**
+   * Generates the mAuth headers from the provided HTTP request data for Mauth V2 or V1 protocol
+   *
+   * NOTE: mAuth headers are time sensitive. The headers must be verified by the receiving service
+   * within 5 minutes of being generated otherwise the request will fail.
+   *
+   * @param httpVerb The HTTP verb of the request, e.g. GET, POST, etc.
+   * @param requestPath The path of the request, not including protocol, host or query parameters.
+   * @param requestPayload The payload of the request
+   * @param queryParameters The query parameters (URL-encoded)
+   * @return MAuth headers which should be appended to the request before sending.
+   * @throws MAuthSigningException when request cannot be signed
+   */
+  Map<String, String> generateRequestHeaders(String httpVerb,
+      String requestPath, InputStream requestPayload, String queryParameters) throws MAuthSigningException;
 }


### PR DESCRIPTION
This PR enhanced mauth-signer and mauth-authenticator to accept the request payload as InputStream.

Note: If payload is stream, 
- mauth-signer generates the signature for v2 only if v2 is required, or the signature for v1 if v1 only is required; 
- mauth-authenticator validates for v2 only if request headers including v2 signature, or validates for v1 if request headers including v1 signature only

@jatcwang @austek @mdsol/architecture-enablement    