### PR TITLE
[MCC-750736]support mauth-protocol-test-suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mauth-protocol-test-suite"]
+	path = mauth-protocol-test-suite
+	url = https://github.com/mdsol/mauth-protocol-test-suite.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- parsing code to test with mauth-protocol-test-suite.
 
 ### Changed
 - Dependency update

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -8,6 +8,17 @@ $ cd mauth-jvm-clients
 $ git checkout develop
 ----
 
+This repo contains the submodule `mauth-protocol-test-suite` so requires a flag when initially cloning in order to clone and init submodules.
+----
+$ git clone --recurse-submodules git@github.com:mdsol/mauth-jvm-clients.git
+----
+
+If you have already cloned before the submodule was introduced, then run:
+----
+$ cd mauth-protocol-test-suite
+$ git submodule update --init
+----
+
 == Git Hooks
 Install desired hook(s)
 

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val `mauth-authenticator-scala` = scalaModuleProject("mauth-authenticator-s
   .settings(
     publishSettings,
     libraryDependencies ++=
-      Dependencies.test(logbackClassic, scalaMock, scalaTest).map(withExclusions)
+      Dependencies.test(logbackClassic, scalaMock, scalaTest, scalaLibCompat).map(withExclusions)
   )
 
 lazy val `mauth-authenticator-apachehttp` = javaModuleProject("mauth-authenticator-apachehttp")

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val `mauth-authenticator` = javaModuleProject("mauth-authenticator")
   )
 
 lazy val `mauth-authenticator-scala` = scalaModuleProject("mauth-authenticator-scala")
-  .dependsOn(`mauth-authenticator`, `mauth-test-utils` % "test")
+  .dependsOn(`mauth-authenticator`, `mauth-signer` % "test", `mauth-test-utils` % "test")
   .settings(
     publishSettings,
     libraryDependencies ++=

--- a/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/MauthProtocolSuiteSpec.scala
+++ b/modules/mauth-authenticator-scala/src/test/scala/com/mdsol/mauth/MauthProtocolSuiteSpec.scala
@@ -1,0 +1,98 @@
+package com.mdsol.mauth
+
+import java.util.UUID
+
+import com.mdsol.mauth.test.utils.ProtocolTestSuiteHelper
+import com.mdsol.mauth.util.MAuthKeysHelper.getPrivateKeyFromString
+import com.mdsol.mauth.util.{EpochTimeProvider, MAuthKeysHelper, MAuthSignatureHelper}
+import com.mdsol.mauth.utils.ClientPublicKeyProvider
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+class MauthProtocolSuiteSpec extends AnyFlatSpec with BeforeAndAfterAll with Matchers with MockFactory {
+
+  val REQUEST_VALIDATION_TIMEOUT_SECONDS: Long = 300L
+  val mockClientPublicKeyProvider: ClientPublicKeyProvider = mock[ClientPublicKeyProvider]
+  val mockEpochTimeProvider: EpochTimeProvider = mock[EpochTimeProvider]
+  val authenticatorV2: RequestAuthenticator =
+    new RequestAuthenticator(mockClientPublicKeyProvider, REQUEST_VALIDATION_TIMEOUT_SECONDS, mockEpochTimeProvider, true)
+
+  behavior of "MauthProtocolSuiteSpec"
+
+  val signingConfig = ProtocolTestSuiteHelper.SIGNING_CONFIG
+  if (signingConfig == null) {
+    fail("Signing Configuration is not available.")
+  }
+
+  if (ProtocolTestSuiteHelper.PUBLIC_KEY == null) {
+    fail("Public Key is not available.")
+  }
+
+  val publicKey = MAuthKeysHelper.getPublicKeyFromString(ProtocolTestSuiteHelper.PUBLIC_KEY)
+  val uuid = UUID.fromString(signingConfig.getAppUuid)
+  val privateKey = getPrivateKeyFromString(signingConfig.getPrivateKey)
+  val mAuthSigner = new DefaultSigner(uuid, privateKey, mockEpochTimeProvider, java.util.Arrays.asList(MAuthVersion.MWSV2))
+
+  // run the tests
+  val testSpecifications = ProtocolTestSuiteHelper.TEST_SPECIFICATIONS
+  testSpecifications.foreach { testSpec =>
+    val authHeader = testSpec.getAuthenticationHeader
+    val unsignedRequest = testSpec.getUnsignedRequest
+    s"Test Case: ${testSpec.getName}" should "pass authentication" in {
+      val mauthRequest = MAuthRequest.Builder.get
+        .withAuthenticationHeaderValue(authHeader.getMccAuthentication)
+        .withTimeHeaderValue(String.valueOf(authHeader.getMccTime))
+        .withHttpMethod(unsignedRequest.getHttpVerb)
+        .withResourcePath(unsignedRequest.getResourcePath)
+        .withQueryParameters(unsignedRequest.getQueryString)
+        .withMessagePayload(unsignedRequest.getBodyInBytes)
+        .build()
+
+      (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(signingConfig.getRequestTime.toLong + 3)
+      (mockClientPublicKeyProvider.getPublicKey _)
+        .expects(uuid)
+        .returns(publicKey)
+      authenticatorV2.authenticate(mauthRequest) shouldBe true
+    }
+
+    if (!testSpec.isAuthenticationOnly) {
+
+      it should "correctly generate the string to sign" in {
+        MAuthSignatureHelper.generateStringToSignV2(
+          uuid,
+          unsignedRequest.getHttpVerb,
+          unsignedRequest.getResourcePath,
+          unsignedRequest.getQueryString,
+          unsignedRequest.getBodyInBytes,
+          signingConfig.getRequestTime
+        ) shouldBe testSpec.getStringToSign
+      }
+
+      it should "correctly generate the signature" in {
+        MAuthSignatureHelper.encryptSignatureRSA(
+          privateKey,
+          testSpec.getStringToSign
+        ) shouldBe testSpec.getSignature
+      }
+
+      it should "correctly generate the authentication headers" in {
+        val httpVerb = unsignedRequest.getHttpVerb
+        val resourcePath = unsignedRequest.getResourcePath
+        val queryString = unsignedRequest.getQueryString
+        val bodyInBytes = unsignedRequest.getBodyInBytes
+        (mockEpochTimeProvider.inSeconds _: () => Long).expects().returns(signingConfig.getRequestTime.toLong)
+        val headers: Map[String, String] =
+          mAuthSigner
+            .generateRequestHeaders(httpVerb, resourcePath, bodyInBytes, queryString)
+            .asScala
+            .toMap
+        headers(MAuthRequest.MCC_AUTHENTICATION_HEADER_NAME) shouldBe authHeader.getMccAuthentication
+        headers(MAuthRequest.MCC_TIME_HEADER_NAME) shouldBe authHeader.getMccTime.toString
+      }
+    }
+  }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
@@ -1,6 +1,7 @@
 package com.mdsol.mauth.test.utils;
 
 import com.mdsol.mauth.test.utils.model.AuthenticationHeader;
+import com.mdsol.mauth.test.utils.model.CaseType;
 import com.mdsol.mauth.test.utils.model.SigningConfig;
 import com.mdsol.mauth.test.utils.model.TestCase;
 import com.mdsol.mauth.test.utils.model.UnsignedRequest;
@@ -57,8 +58,10 @@ public class ProtocolTestSuiteHelper {
       String caseFile = caseName.concat("/").concat(caseName);
       TestCase newCase = new TestCase(caseName);
       boolean isAuthenticationOnly = caseName.contains("authentication-only");
-      newCase.setAuthenticationOnly(isAuthenticationOnly);
-      if (!isAuthenticationOnly) {
+      if(isAuthenticationOnly) {
+        newCase.setCaseType(CaseType.AUTHENTICATION_ONLY);
+      } else {
+        newCase.setCaseType(CaseType.SIGNING_AUTHENTICATION);
         newCase.setStringToSign(loadTestDataAsString(caseFile.concat(".sts")));
         newCase.setSignature(loadTestDataAsString(caseFile.concat(".sig")));
       }

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
@@ -44,7 +44,7 @@ public class ProtocolTestSuiteHelper {
     try {
       tmp = new String(Files.readAllBytes(normalizePath(filePath)), StandardCharsets.UTF_8);
     } catch (IOException ex) {
-      ex.printStackTrace();
+      throw new IllegalStateException("Failed to load the public key " + filePath, ex);
     }
     PUBLIC_KEY = tmp;
   }
@@ -78,7 +78,7 @@ public class ProtocolTestSuiteHelper {
     try {
       privateKey = new String(Files.readAllBytes(filePath), Charset.defaultCharset());
     } catch (IOException ex) {
-      ex.printStackTrace();
+      throw new IllegalStateException("Failed to load the private key " + filePath, ex);
     }
     return privateKey;
   }
@@ -100,8 +100,8 @@ public class ProtocolTestSuiteHelper {
     try {
       bytes = Files.readAllBytes(path);
     } catch (IOException ex) {
-      ex.printStackTrace();
-    }
+      throw new IllegalStateException("Failed to load " + filePath, ex);
+     }
     return bytes;
   }
 
@@ -117,7 +117,7 @@ public class ProtocolTestSuiteHelper {
       ObjectMapper objectMapper = new ObjectMapper();
       unsignedRequest = objectMapper.readValue(jsonData, UnsignedRequest.class);
     } catch (IOException ex) {
-      ex.printStackTrace();
+      throw new IllegalStateException("Failed to load " + filePath, ex);
     }
     return unsignedRequest;
   }
@@ -141,7 +141,7 @@ public class ProtocolTestSuiteHelper {
       ObjectMapper objectMapper = new ObjectMapper();
       authenticationHeader = objectMapper.readValue(jsonData, AuthenticationHeader.class);
     } catch (IOException ex) {
-      ex.printStackTrace();
+      throw new IllegalStateException("Failed to load " + filePath, ex);
     }
     return authenticationHeader;
   }

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
@@ -1,0 +1,158 @@
+package com.mdsol.mauth.test.utils;
+
+import com.mdsol.mauth.test.utils.model.AuthenticationHeader;
+import com.mdsol.mauth.test.utils.model.SigningConfig;
+import com.mdsol.mauth.test.utils.model.TestCase;
+import com.mdsol.mauth.test.utils.model.UnsignedRequest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProtocolTestSuiteHelper {
+
+  final static String TEST_SUITE_RELATIVE_PATH = "../../mauth-protocol-test-suite/";
+  final static String MWSV2_TEST_CASE_PATH = getFullFilePath("protocols/MWSV2/");
+
+  public final static SigningConfig SIGNING_CONFIG;
+  static {
+    SigningConfig tmp = null;
+    String configFile = getFullFilePath("signing-config.json");
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      byte[] jsonData = Files.readAllBytes(normalizePath(configFile));
+      tmp = objectMapper.readValue(jsonData, SigningConfig.class);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+    SIGNING_CONFIG = tmp;
+  }
+
+  public final static String PUBLIC_KEY ;
+  static {
+    String tmp = null;
+    String filePath = getFullFilePath("signing-params/rsa-key-pub");
+    try {
+      tmp = new String(Files.readAllBytes(normalizePath(filePath)), Charset.defaultCharset());
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+    PUBLIC_KEY = tmp;
+  }
+
+  public final static TestCase[] TEST_SPECIFICATIONS;
+  static {
+    List<TestCase> testCaseList = new ArrayList<TestCase>();
+    String[] cases = retrieveV2TestCases();
+    for (String caseName : cases) {
+      String caseFile = caseName.concat("/").concat(caseName);
+      TestCase newCase = new TestCase(caseName);
+      boolean isAuthenticationOnly = caseName.contains("authentication-only");
+      newCase.authenticationOnly(isAuthenticationOnly);
+      if (!isAuthenticationOnly) {
+        newCase.setStringToSign(loadTestDataAsString(caseFile.concat(".sts")));
+        newCase.setSignature(loadTestDataAsString(caseFile.concat(".sig")));
+      }
+      newCase.setAuthenticationHeader(loadAuthenticationHeader(caseFile.concat(".authz")));
+      UnsignedRequest unsignedRequest = loadUnsignedRequest(caseFile.concat(".req"));
+      if (unsignedRequest != null) {
+        byte[] bodyInBytes = getTestRequestBody(unsignedRequest, caseName);
+        unsignedRequest.setBBodyInBytes(bodyInBytes);
+        newCase.setUnsignedRequest(unsignedRequest);
+      }
+      testCaseList.add(newCase);
+    }
+    TEST_SPECIFICATIONS = testCaseList.toArray(new TestCase[0]);
+  }
+
+  public static String loadPrivateKey(String keyFile) {
+    String privateKey = "";
+    Path filePath = normalizePath(getFullFilePath(keyFile));
+    try {
+      privateKey = new String(Files.readAllBytes(filePath), Charset.defaultCharset());
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+    return privateKey;
+  }
+
+  private static String[] retrieveV2TestCases() {
+    File file = new File(MWSV2_TEST_CASE_PATH);
+    String[] directories = file.list(new FilenameFilter() {
+      @Override
+      public boolean accept(File current, String name) {
+        return new File(current, name).isDirectory();
+      }
+    });
+    return directories;
+  }
+
+  private static byte[] loadTestData(String filePath) {
+    byte[] bytes = {};
+    Path path = normalizePath(MWSV2_TEST_CASE_PATH + filePath);
+    try {
+      bytes = Files.readAllBytes(path);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+    return bytes;
+  }
+
+  private static String loadTestDataAsString(String filePath) {
+    byte[] bytes = loadTestData(filePath);
+    return bytes.length==0 ? "" : new String(bytes, Charset.defaultCharset());
+  }
+
+  private static UnsignedRequest loadUnsignedRequest(String filePath) {
+    UnsignedRequest unsignedRequest = new UnsignedRequest();
+    byte[] jsonData = loadTestData(filePath);
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      unsignedRequest = objectMapper.readValue(jsonData, UnsignedRequest.class);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+    return unsignedRequest;
+  }
+
+  private static byte[] getTestRequestBody(UnsignedRequest unsignedRequest, String caseName) {
+    byte[] bytes = new byte[0];
+    if (unsignedRequest.getBodyFilepath() != null) {
+      String bodyFile = caseName.concat("/").concat(unsignedRequest.getBodyFilepath());
+      bytes = ProtocolTestSuiteHelper.loadTestData(bodyFile);
+    }
+    else if (unsignedRequest.getHttpVerb() != null) {
+      bytes = unsignedRequest.getBody().getBytes(StandardCharsets.UTF_8);
+    }
+    return bytes;
+  }
+
+  private static AuthenticationHeader loadAuthenticationHeader(String filePath) {
+    AuthenticationHeader authenticationHeader = new AuthenticationHeader();
+    byte[] jsonData = loadTestData(filePath);
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      authenticationHeader = objectMapper.readValue(jsonData, AuthenticationHeader.class);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+    return authenticationHeader;
+  }
+
+  private static Path normalizePath(String filepath) {
+    return Paths.get(filepath).normalize();
+  }
+
+  private static String getFullFilePath(String filePath) {
+    return TEST_SUITE_RELATIVE_PATH + filePath;
+  }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/ProtocolTestSuiteHelper.java
@@ -32,7 +32,7 @@ public class ProtocolTestSuiteHelper {
       byte[] jsonData = Files.readAllBytes(normalizePath(configFile));
       tmp = objectMapper.readValue(jsonData, SigningConfig.class);
     } catch (IOException ex) {
-      ex.printStackTrace();
+      throw new IllegalStateException("Failed to load the config file " + configFile, ex);
     }
     SIGNING_CONFIG = tmp;
   }
@@ -42,7 +42,7 @@ public class ProtocolTestSuiteHelper {
     String tmp = null;
     String filePath = getFullFilePath("signing-params/rsa-key-pub");
     try {
-      tmp = new String(Files.readAllBytes(normalizePath(filePath)), Charset.defaultCharset());
+      tmp = new String(Files.readAllBytes(normalizePath(filePath)), StandardCharsets.UTF_8);
     } catch (IOException ex) {
       ex.printStackTrace();
     }
@@ -57,18 +57,16 @@ public class ProtocolTestSuiteHelper {
       String caseFile = caseName.concat("/").concat(caseName);
       TestCase newCase = new TestCase(caseName);
       boolean isAuthenticationOnly = caseName.contains("authentication-only");
-      newCase.authenticationOnly(isAuthenticationOnly);
+      newCase.setAuthenticationOnly(isAuthenticationOnly);
       if (!isAuthenticationOnly) {
         newCase.setStringToSign(loadTestDataAsString(caseFile.concat(".sts")));
         newCase.setSignature(loadTestDataAsString(caseFile.concat(".sig")));
       }
       newCase.setAuthenticationHeader(loadAuthenticationHeader(caseFile.concat(".authz")));
       UnsignedRequest unsignedRequest = loadUnsignedRequest(caseFile.concat(".req"));
-      if (unsignedRequest != null) {
-        byte[] bodyInBytes = getTestRequestBody(unsignedRequest, caseName);
-        unsignedRequest.setBBodyInBytes(bodyInBytes);
-        newCase.setUnsignedRequest(unsignedRequest);
-      }
+      byte[] bodyInBytes = getTestRequestBody(unsignedRequest, caseName);
+      unsignedRequest.setBodyInBytes(bodyInBytes);
+      newCase.setUnsignedRequest(unsignedRequest);
       testCaseList.add(newCase);
     }
     TEST_SPECIFICATIONS = testCaseList.toArray(new TestCase[0]);

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/AuthenticationHeader.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/AuthenticationHeader.java
@@ -1,0 +1,18 @@
+package com.mdsol.mauth.test.utils.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthenticationHeader {
+  @JsonProperty("MCC-Authentication")
+  String mccAuthentication;
+  @JsonProperty("MCC-Time")
+  Long mccTime;
+
+  public String getMccAuthentication() { return mccAuthentication; }
+
+  public void setMccAuthentication(String mccAuthentication) { this.mccAuthentication = mccAuthentication; }
+
+  public long getMccTime() { return mccTime; }
+
+  public void setMccTime(Long mccTime) { this.mccTime = mccTime; }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/AuthenticationOnly.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/AuthenticationOnly.java
@@ -1,0 +1,30 @@
+package com.mdsol.mauth.test.utils.model;
+
+public class AuthenticationOnly implements TestCase {
+  String name;
+  AuthenticationHeader authHeader;
+  UnsignedRequest unsignedRequest;
+
+  public AuthenticationOnly(
+      String name,
+      UnsignedRequest unsignedRequest,
+      AuthenticationHeader authHeader) {
+    this.name = name;
+    this.unsignedRequest = unsignedRequest;
+    this.authHeader = authHeader;
+  }
+
+  @Override
+  public String getName() { return name; }
+
+  @Override
+  public CaseType getType() { return CaseType.AUTHENTICATION_ONLY; }
+
+  public UnsignedRequest getUnsignedRequest() { return unsignedRequest; }
+
+  public void setUnsignedRequest(UnsignedRequest unsignedRequest) { this.unsignedRequest = unsignedRequest; }
+
+  public AuthenticationHeader getAuthenticationHeader() { return authHeader; }
+
+  public void setAuthenticationHeader(AuthenticationHeader authHeader) { this.authHeader = authHeader; }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/CaseType.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/CaseType.java
@@ -1,0 +1,6 @@
+package com.mdsol.mauth.test.utils.model;
+
+public enum CaseType {
+  AUTHENTICATION_ONLY,
+  SIGNING_AUTHENTICATION
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/SigningAuthentication.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/SigningAuthentication.java
@@ -1,0 +1,44 @@
+package com.mdsol.mauth.test.utils.model;
+
+public class SigningAuthentication implements TestCase {
+  String name;
+  String stringToSign;
+  String signature;
+  AuthenticationHeader authHeader;
+  UnsignedRequest unsignedRequest;
+
+  public SigningAuthentication(
+      String name,
+      UnsignedRequest unsignedRequest,
+      AuthenticationHeader authHeader,
+      String stringToSign,
+      String signature) {
+    this.name = name;
+    this.unsignedRequest = unsignedRequest;
+    this.authHeader = authHeader;
+    this.stringToSign = stringToSign;
+    this.signature = signature;
+  }
+
+  @Override
+  public String getName() { return name; }
+
+  @Override
+  public CaseType getType() { return CaseType.SIGNING_AUTHENTICATION; }
+
+  public String getStringToSign() { return stringToSign; }
+
+  public void setStringToSign(String stringToSign) { this.stringToSign = stringToSign; }
+
+  public String getSignature() { return signature; }
+
+  public void setSignature(String signature) { this.signature = signature; }
+
+  public UnsignedRequest getUnsignedRequest() { return unsignedRequest; }
+
+  public void setUnsignedRequest(UnsignedRequest unsignedRequest) { this.unsignedRequest = unsignedRequest; }
+
+  public AuthenticationHeader getAuthenticationHeader() { return authHeader; }
+
+  public void setAuthenticationHeader(AuthenticationHeader authHeader) { this.authHeader = authHeader; }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/SigningConfig.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/SigningConfig.java
@@ -1,0 +1,33 @@
+package com.mdsol.mauth.test.utils.model;
+
+import com.mdsol.mauth.test.utils.ProtocolTestSuiteHelper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SigningConfig {
+  @JsonProperty("app_uuid")
+  String appUuid;
+  @JsonProperty("request_time")
+  String requestTime;
+  @JsonProperty("private_key_file")
+  String privateKeyFile;
+
+  String privateKey;
+
+  public String getAppUuid() { return appUuid; }
+
+  public void setAppUuid(String appUuid) { this.appUuid = appUuid; }
+
+  public String getRequestTime() { return requestTime; }
+
+  public void setRequestTime(String requestTime) { this.requestTime = requestTime; }
+
+  public String getPrivateKeyFile() { return privateKeyFile; }
+
+  public void setPrivateKeyFile(String privateKeyFile) {
+    this.privateKeyFile = privateKeyFile;
+    privateKey = ProtocolTestSuiteHelper.loadPrivateKey(privateKeyFile);
+  }
+
+  public String getPrivateKey() { return privateKey; }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
@@ -6,7 +6,7 @@ public class TestCase {
   String signature;
   AuthenticationHeader authHeader;
   UnsignedRequest unsignedRequest;
-  boolean authenticationOnly = false;
+  CaseType caseType;
 
   public TestCase(String name) {
     this.name = name;
@@ -14,9 +14,9 @@ public class TestCase {
 
   public String getName() { return name; }
 
-  public boolean isAuthenticationOnly() { return authenticationOnly; }
+  public CaseType getCaseType() { return caseType; }
 
-  public void setAuthenticationOnly(boolean authenticationOnly) { this.authenticationOnly = authenticationOnly; }
+  public void setCaseType(CaseType caseType) { this.caseType = caseType; }
 
   public String getStringToSign() { return stringToSign; }
 

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
@@ -1,36 +1,6 @@
 package com.mdsol.mauth.test.utils.model;
 
-public class TestCase {
-  String name;
-  String stringToSign;
-  String signature;
-  AuthenticationHeader authHeader;
-  UnsignedRequest unsignedRequest;
-  CaseType caseType;
-
-  public TestCase(String name) {
-    this.name = name;
-  }
-
-  public String getName() { return name; }
-
-  public CaseType getCaseType() { return caseType; }
-
-  public void setCaseType(CaseType caseType) { this.caseType = caseType; }
-
-  public String getStringToSign() { return stringToSign; }
-
-  public void setStringToSign(String stringToSign) { this.stringToSign = stringToSign; }
-
-  public String getSignature() { return signature; }
-
-  public void setSignature(String signature) { this.signature = signature; }
-
-  public UnsignedRequest getUnsignedRequest() { return unsignedRequest; }
-
-  public void setUnsignedRequest(UnsignedRequest unsignedRequest) { this.unsignedRequest = unsignedRequest; }
-
-  public AuthenticationHeader getAuthenticationHeader() { return authHeader; }
-
-  public void setAuthenticationHeader(AuthenticationHeader authHeader) { this.authHeader = authHeader; }
+public interface TestCase {
+  String getName();
+  CaseType getType();
 }

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
@@ -16,7 +16,7 @@ public class TestCase {
 
   public boolean isAuthenticationOnly() { return authenticationOnly; }
 
-  public void authenticationOnly(boolean authenticationOnly) { this.authenticationOnly = authenticationOnly; }
+  public void setAuthenticationOnly(boolean authenticationOnly) { this.authenticationOnly = authenticationOnly; }
 
   public String getStringToSign() { return stringToSign; }
 

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/TestCase.java
@@ -1,0 +1,36 @@
+package com.mdsol.mauth.test.utils.model;
+
+public class TestCase {
+  String name;
+  String stringToSign;
+  String signature;
+  AuthenticationHeader authHeader;
+  UnsignedRequest unsignedRequest;
+  boolean authenticationOnly = false;
+
+  public TestCase(String name) {
+    this.name = name;
+  }
+
+  public String getName() { return name; }
+
+  public boolean isAuthenticationOnly() { return authenticationOnly; }
+
+  public void authenticationOnly(boolean authenticationOnly) { this.authenticationOnly = authenticationOnly; }
+
+  public String getStringToSign() { return stringToSign; }
+
+  public void setStringToSign(String stringToSign) { this.stringToSign = stringToSign; }
+
+  public String getSignature() { return signature; }
+
+  public void setSignature(String signature) { this.signature = signature; }
+
+  public UnsignedRequest getUnsignedRequest() { return unsignedRequest; }
+
+  public void setUnsignedRequest(UnsignedRequest unsignedRequest) { this.unsignedRequest = unsignedRequest; }
+
+  public AuthenticationHeader getAuthenticationHeader() { return authHeader; }
+
+  public void setAuthenticationHeader(AuthenticationHeader authHeader) { this.authHeader = authHeader; }
+}

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/UnsignedRequest.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/UnsignedRequest.java
@@ -43,7 +43,7 @@ public class UnsignedRequest {
 
   public byte[] getBodyInBytes() { return bodyInBytes; }
 
-  public void setBBodyInBytes(byte[] bodyInBytes) {
+  public void setBodyInBytes(byte[] bodyInBytes) {
     this.bodyInBytes = bodyInBytes == null? "".getBytes(StandardCharsets.UTF_8) : bodyInBytes;
   }
 

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/UnsignedRequest.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/model/UnsignedRequest.java
@@ -1,0 +1,57 @@
+package com.mdsol.mauth.test.utils.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.nio.charset.StandardCharsets;
+
+public class UnsignedRequest {
+  @JsonProperty("verb")
+  String httpVerb;
+  @JsonProperty("url")
+  String urlString;
+  @JsonProperty("body_filepath")
+  String bodyFilepath;
+  @JsonProperty("body")
+  String body;
+
+  String resourcePath;
+  String queryString;
+  byte[] bodyInBytes;
+
+  public String getHttpVerb() { return httpVerb; }
+
+  public void setHttpVerb(String httpVerb) { this.httpVerb = httpVerb; }
+
+  public String getUrlString() { return urlString; }
+
+  public void setUrlString(String urlString) {
+    this.urlString = urlString;
+    int idx = urlString.indexOf('?');
+    if (idx == -1 || idx == urlString.length()-1) {
+      this.resourcePath = urlString;
+      this.queryString = "";
+    }
+    else {
+      this.resourcePath = urlString.substring(0, idx);
+      this.queryString = urlString.substring(idx+1);
+    }
+  }
+
+  public String getBody() { return body; }
+
+  public void setBody(String body) { this.body = body == null? "" : body; }
+
+  public byte[] getBodyInBytes() { return bodyInBytes; }
+
+  public void setBBodyInBytes(byte[] bodyInBytes) {
+    this.bodyInBytes = bodyInBytes == null? "".getBytes(StandardCharsets.UTF_8) : bodyInBytes;
+  }
+
+  public String getBodyFilepath() { return bodyFilepath; }
+
+  public void setBodyFilepath(String bodyFilepath) { this.bodyFilepath = bodyFilepath; }
+
+  public String getResourcePath() { return resourcePath; }
+
+  public String getQueryString() { return queryString; }
+}


### PR DESCRIPTION
This PR is for supporting [mauth-protocol-test-suite](https://github.com/mdsol/mauth-protocol-test-suite) 
- ProtocolTestSuiteHelper to retrieve the test specs in mauth-protocol-test-suite
- run test specs for verification 
- include submodule mauth-protocol-test-suite in the repo

@mdsol/architecture-enablement @austek @jatcwang 