### PR TITLE
[MCC-785068] Use Cache Control header as TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - parsing code to test with mauth-protocol-test-suite.
+- Caffeine dependency for local cache
 
 ### Changed
 - Dependency update
   - Update sttp to 3.x from 2.x. Note this is a new major sttp version with new package prefix `sttp.client3`
   - Remove silencer as 2.12.13 also got configurable warnings now
-  
+- Use Caffeine as local cache instead of Guava Cache
+- Added Cache-Control header in FakeMauthServer success response
+- Use Cache-Control max-age header as ttl in public key local cache and only set configuration value as fallback
+
 ## Removed
 - Removed mauth-proxy. The library we depend on (littleproxy) has been unmaintained for a long time
   and there are better mauth proxy alternatives like https://github.com/mdsol/go-mauth-proxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.1] - 2021-07-15
 ### Added
 - parsing code to test with mauth-protocol-test-suite.
 - Caffeine dependency for local cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.0.1] - 2021-07-15
+## [Unreleased]
 ### Added
 - parsing code to test with mauth-protocol-test-suite.
 - Caffeine dependency for local cache

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val `mauth-signer-apachehttp` = javaModuleProject("mauth-signer-apachehttp"
     publishSettings,
     libraryDependencies ++=
       Dependencies.compile(apacheHttpClient).map(withExclusions) ++
+        Dependencies.compile(caffeine).map(withExclusions) ++
         Dependencies.test(scalaMock, scalaTest).map(withExclusions)
   )
 

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -118,8 +118,7 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
 
     public Optional<Long> getMaxAge(HttpResponse response) {
       return Optional.ofNullable(response.getFirstHeader(HttpHeaders.CACHE_CONTROL))
-        .map(Header::getElements)
-        .flatMap(elements -> Arrays.stream(elements)
+        .flatMap(header -> Arrays.stream(header.getElements())
           .filter(e -> e.getName().equalsIgnoreCase(MAX_AGE))
           .findFirst()
           .map(e -> Long.parseLong(e.getValue()))

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -117,8 +117,8 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
     }
 
     public Optional<Long> getMaxage(HttpResponse response) {
-      if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL.toLowerCase()) != null) {
-        HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL.toLowerCase()).getElements();
+      if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL) != null) {
+        HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL).getElements();
         return Arrays.stream(elements)
           .filter(e -> e.getName().equals(MAX_AGE))
           .findFirst()

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -103,7 +103,7 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
     public String handleResponse(HttpResponse response) throws IOException {
       if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
         if (ttl == null) {
-          ttl = getMaxage(response).orElse(configuration.getTimeToLive());
+          ttl = getMaxAge(response).orElse(configuration.getTimeToLive());
         }
 
         HttpEntity entity = response.getEntity();
@@ -116,7 +116,7 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
       }
     }
 
-    public Optional<Long> getMaxage(HttpResponse response) {
+    public Optional<Long> getMaxAge(HttpResponse response) {
       if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL) != null) {
         HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL).getElements();
         return Arrays.stream(elements)

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -117,14 +117,13 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
     }
 
     public Optional<Long> getMaxAge(HttpResponse response) {
-      if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL) != null) {
-        HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL).getElements();
-        return Arrays.stream(elements)
+      return Optional.ofNullable(response.getFirstHeader(HttpHeaders.CACHE_CONTROL))
+        .map(Header::getElements)
+        .flatMap(elements -> Arrays.stream(elements)
           .filter(e -> e.getName().equalsIgnoreCase(MAX_AGE))
           .findFirst()
-          .map(e -> Long.parseLong(e.getValue()));
-      }
-      return Optional.empty();
+          .map(e -> Long.parseLong(e.getValue()))
+        );
     }
   }
 }

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -117,12 +117,12 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
     }
 
     public Optional<Long> getMaxAge(HttpResponse response) {
-      return Optional.ofNullable(response.getFirstHeader(HttpHeaders.CACHE_CONTROL))
-        .flatMap(header -> Arrays.stream(header.getElements())
-          .filter(e -> e.getName().equalsIgnoreCase(MAX_AGE))
-          .findFirst()
-          .map(e -> Long.parseLong(e.getValue()))
-        );
+      return Optional.ofNullable(response.getHeaders(HttpHeaders.CACHE_CONTROL))
+        .flatMap(headers -> Arrays.stream(headers)
+          .flatMap(header -> Arrays.stream(header.getElements())
+            .filter(e -> e.getName().equalsIgnoreCase(MAX_AGE))
+            .map(e -> Long.parseLong(e.getValue())))
+          .findFirst());
     }
   }
 }

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -74,7 +74,7 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
       }
       return publicKeyCache.get(appUUID);
     } catch (Exception e) {
-      logger.error("Couldn't find public key", e);
+      logger.error("Public key retrieval error", e);
       throw new HttpClientPublicKeyProviderException(e);
     }
   }
@@ -117,8 +117,8 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
     }
 
     public Optional<Long> getMaxage(HttpResponse response) {
-      if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL) != null) {
-        HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL).getElements();
+      if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL.toLowerCase()) != null) {
+        HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL.toLowerCase()).getElements();
         return Arrays.stream(elements)
           .filter(e -> e.getName().equals(MAX_AGE))
           .findFirst()

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -120,7 +120,7 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
       if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL) != null) {
         HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL).getElements();
         return Arrays.stream(elements)
-          .filter(e -> e.getName().equals(MAX_AGE))
+          .filter(e -> e.getName().equalsIgnoreCase(MAX_AGE))
           .findFirst()
           .map(e -> Long.parseLong(e.getValue()));
       }

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -50,10 +50,10 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
     publicKeyCache =
       Caffeine.newBuilder()
         .expireAfterAccess(ttl, TimeUnit.SECONDS)
-        .build(this::getPublicKeyFromEureka);
+        .build(this::getPublicKeyFromMauth);
   }
 
-  private PublicKey getPublicKeyFromEureka(UUID appUUID) {
+  private PublicKey getPublicKeyFromMauth(UUID appUUID) {
     byte[] payload = new byte[0];
     String requestUrlPath = getRequestUrlPath(appUUID);
     Map<String, String> headers = signer.generateRequestHeaders("GET", requestUrlPath, payload, "");
@@ -68,7 +68,7 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
       if (publicKeyCache == null) {
         // Lazy load public key cache so that we can set the ttl based on the first response max-age
         // Do Eureka call first to set the ttl
-        PublicKey key = getPublicKeyFromEureka(appUUID);
+        PublicKey key = getPublicKeyFromMauth(appUUID);
         setupCache();
         publicKeyCache.put(appUUID, key);
       }

--- a/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
+++ b/modules/mauth-authenticator-apachehttp/src/main/java/com/mdsol/mauth/apache/HttpClientPublicKeyProvider.java
@@ -1,18 +1,14 @@
 package com.mdsol.mauth.apache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.mdsol.mauth.AuthenticatorConfiguration;
 import com.mdsol.mauth.Signer;
 import com.mdsol.mauth.exception.HttpClientPublicKeyProviderException;
 import com.mdsol.mauth.util.MAuthKeysHelper;
 import com.mdsol.mauth.utils.ClientPublicKeyProvider;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
+import org.apache.http.*;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -24,8 +20,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -39,25 +37,20 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
   private final PublicKeyResponseHandler publicKeyResponseHandler;
 
   private LoadingCache<UUID, PublicKey> publicKeyCache;
+  private Long ttl;
 
   public HttpClientPublicKeyProvider(AuthenticatorConfiguration configuration, Signer signer) {
     this.configuration = configuration;
     this.signer = signer;
     this.httpclient = HttpClients.createDefault();
     this.publicKeyResponseHandler = new PublicKeyResponseHandler();
-    setupCache(configuration.getTimeToLive());
   }
 
-  private void setupCache(long timeToLiveInSeconds) {
+  private void setupCache() {
     publicKeyCache =
-        CacheBuilder.newBuilder()
-            .expireAfterAccess(timeToLiveInSeconds, TimeUnit.SECONDS)
-            .build(new CacheLoader<UUID, PublicKey>() {
-              @Override
-              public PublicKey load(UUID appUUID) throws Exception {
-                return getPublicKeyFromEureka(appUUID);
-              }
-            });
+      Caffeine.newBuilder()
+        .expireAfterAccess(ttl, TimeUnit.SECONDS)
+        .build(this::getPublicKeyFromEureka);
   }
 
   private PublicKey getPublicKeyFromEureka(UUID appUUID) {
@@ -72,6 +65,13 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
   @Override
   public PublicKey getPublicKey(UUID appUUID) {
     try {
+      if (publicKeyCache == null) {
+        // Lazy load public key cache so that we can set the ttl based on the first response max-age
+        // Do Eureka call first to set the ttl
+        PublicKey key = getPublicKeyFromEureka(appUUID);
+        setupCache();
+        publicKeyCache.put(appUUID, key);
+      }
       return publicKeyCache.get(appUUID);
     } catch (Exception e) {
       logger.error("Couldn't find public key", e);
@@ -96,18 +96,35 @@ public class HttpClientPublicKeyProvider implements ClientPublicKeyProvider {
   }
 
   private class PublicKeyResponseHandler implements ResponseHandler<String> {
+    private static final String MAX_AGE = "max-age";
+    private static final String PUBLIC_KEY_STR = "public_key_str";
 
     @Override
     public String handleResponse(HttpResponse response) throws IOException {
       if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+        if (ttl == null) {
+          ttl = getMaxage(response).orElse(configuration.getTimeToLive());
+        }
+
         HttpEntity entity = response.getEntity();
         String responseAsString = EntityUtils.toString(entity, StandardCharsets.UTF_8);
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.readTree(responseAsString).findValue("public_key_str").asText();
+        return mapper.readTree(responseAsString).findValue(PUBLIC_KEY_STR).asText();
       } else {
         throw new HttpClientPublicKeyProviderException("Invalid response code returned by server: "
-            + response.getStatusLine().getStatusCode());
+          + response.getStatusLine().getStatusCode());
       }
+    }
+
+    public Optional<Long> getMaxage(HttpResponse response) {
+      if (response.getFirstHeader(HttpHeaders.CACHE_CONTROL) != null) {
+        HeaderElement[] elements = response.getFirstHeader(HttpHeaders.CACHE_CONTROL).getElements();
+        return Arrays.stream(elements)
+          .filter(e -> e.getName().equals(MAX_AGE))
+          .findFirst()
+          .map(e -> Long.parseLong(e.getValue()));
+      }
+      return Optional.empty();
     }
   }
 }

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
@@ -39,7 +39,7 @@ public class FakeMAuthServer {
   public static void return200() {
     WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/mauth/v1/security_tokens/" + EXISTING_CLIENT_APP_UUID.toString() + ".json"))
         .willReturn(WireMock.aResponse().withStatus(200).withBody(mockedMauthTokenResponse())
-          .withHeader(HttpHeaders.CACHE_CONTROL.toLowerCase(), "max-age=3600, private")));
+          .withHeader(HttpHeaders.CACHE_CONTROL, "max-age=3600, private")));
   }
 
   public static void return401() {

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
@@ -39,7 +39,7 @@ public class FakeMAuthServer {
   public static void return200() {
     WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/mauth/v1/security_tokens/" + EXISTING_CLIENT_APP_UUID.toString() + ".json"))
         .willReturn(WireMock.aResponse().withStatus(200).withBody(mockedMauthTokenResponse())
-          .withHeader(HttpHeaders.CACHE_CONTROL, "max-age=3600, private")));
+          .withHeader(HttpHeaders.CACHE_CONTROL.toLowerCase(), "max-age=3600, private")));
   }
 
   public static void return401() {

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
@@ -38,7 +38,8 @@ public class FakeMAuthServer {
 
   public static void return200() {
     WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/mauth/v1/security_tokens/" + EXISTING_CLIENT_APP_UUID.toString() + ".json"))
-        .willReturn(WireMock.aResponse().withStatus(200).withBody(mockedMauthTokenResponse()).withHeader(HttpHeaders.CACHE_CONTROL, "max-age=3600, private")));
+        .willReturn(WireMock.aResponse().withStatus(200).withBody(mockedMauthTokenResponse())
+          .withHeader(HttpHeaders.CACHE_CONTROL, "max-age=3600, private")));
   }
 
   public static void return401() {

--- a/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
+++ b/modules/mauth-test-utils/src/main/java/com/mdsol/mauth/test/utils/FakeMAuthServer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.apache.http.HttpHeaders;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -37,7 +38,7 @@ public class FakeMAuthServer {
 
   public static void return200() {
     WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/mauth/v1/security_tokens/" + EXISTING_CLIENT_APP_UUID.toString() + ".json"))
-        .willReturn(WireMock.aResponse().withStatus(200).withBody(mockedMauthTokenResponse())));
+        .willReturn(WireMock.aResponse().withStatus(200).withBody(mockedMauthTokenResponse()).withHeader(HttpHeaders.CACHE_CONTROL, "max-age=3600, private")));
   }
 
   public static void return401() {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies extends DependencyUtils {
   val sttp: ModuleID = "com.softwaremill.sttp.client3"                %% "core"                    % Version.sttp
   val sttpAkkaHttpBackend: ModuleID = "com.softwaremill.sttp.client3" %% "akka-http-backend"       % Version.sttp
   val scalaLibCompat: ModuleID = "org.scala-lang.modules"             %% "scala-collection-compat" % "2.4.3"
+  val caffeine: ModuleID = "com.github.ben-manes.caffeine"             % "caffeine"                % "2.9.1"
 
   // TEST DEPENDENCIES
   val akkaHttpTestKit: Seq[ModuleID] = Seq(


### PR DESCRIPTION
- Honor Cache-Control max-age header as cache ttl
- Lazy load LoadingCache object to be able to set the ttl
- Add Caffeine library dependency for more efficient caching ([benchmarks](https://github.com/ben-manes/caffeine/wiki/Benchmarks))
- Add Cache-Control headers in FakeMauthServer response