### PR TITLE
[MCC-805832]Set the fallback cache TTL to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- update the client fallbacks to caching for 5 minutes if Cache-Control is missing or malformed.
-- Make that value `unconfigurable` to prevent user introduced discrepancies. 
+- Cache responses for 5 minutes (non configurable) as a fallback when the Cache-Control header is missing or malformed.
 
 ## [6.0.1] - 2021-07-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- update the client fallbacks to caching for 5 minutes if Cache-Control is missing or malformed.
+- Make that value `unconfigurable` to prevent user introduced discrepancies. 
 
 ## [6.0.1] - 2021-07-21
 ### Added

--- a/modules/mauth-authenticator-akka-http/src/test/scala/com/mdsol/mauth/akka/http/MauthPublicKeyProviderSpec.scala
+++ b/modules/mauth-authenticator-akka-http/src/test/scala/com/mdsol/mauth/akka/http/MauthPublicKeyProviderSpec.scala
@@ -32,7 +32,6 @@ class MauthPublicKeyProviderSpec
   private val MAUTH_BASE_URL = s"http://localhost:$MAUTH_PORT"
   private val MAUTH_URL_PATH = "/mauth/v1"
   private val SECURITY_TOKENS_PATH = "/security_tokens/%s.json"
-  private val FIVE_MINUTES = 300L
 
   val mauthHeadersWithValue = Map(
     MAuthRequest.X_MWS_AUTHENTICATION_HEADER_NAME -> EXPECTED_AUTHENTICATION_HEADER_VALUE,
@@ -53,7 +52,7 @@ class MauthPublicKeyProviderSpec
 
   private def getRequestUrlPath(clientAppId: String) = String.format(MAUTH_URL_PATH + SECURITY_TOKENS_PATH, clientAppId)
 
-  private def getMAuthConfiguration = new AuthenticatorConfiguration(MAUTH_BASE_URL, MAUTH_URL_PATH, SECURITY_TOKENS_PATH, FIVE_MINUTES)
+  private def getMAuthConfiguration = new AuthenticatorConfiguration(MAUTH_BASE_URL, MAUTH_URL_PATH, SECURITY_TOKENS_PATH)
 
   "MauthPublicKeyProvider" should "retrieve PublicKey from MAuth Server" in {
     FakeMAuthServer.return200()

--- a/modules/mauth-authenticator-apachehttp/src/test/scala/com/mdsol/mauth/apache/HttpClientPublicKeyProviderSpec.scala
+++ b/modules/mauth-authenticator-apachehttp/src/test/scala/com/mdsol/mauth/apache/HttpClientPublicKeyProviderSpec.scala
@@ -24,7 +24,6 @@ class HttpClientPublicKeyProviderSpec extends AnyFlatSpec with Matchers with Moc
   private val MAUTH_BASE_URL: String = s"http://localhost:$port"
   private val MAUTH_URL_PATH: String = "/mauth/v1"
   private val SECURITY_TOKENS_PATH: String = "/security_tokens/%s.json"
-  private val timeToLive = 300L
 
   override protected def beforeAll(): Unit = {
     FakeMAuthServer.start(port)
@@ -53,7 +52,7 @@ class HttpClientPublicKeyProviderSpec extends AnyFlatSpec with Matchers with Moc
   private def getRequestUrlPath(clientAppId: String): String = String.format(MAUTH_URL_PATH + SECURITY_TOKENS_PATH, clientAppId)
 
   private def getMAuthConfiguration: AuthenticatorConfiguration =
-    new AuthenticatorConfiguration(MAUTH_BASE_URL, MAUTH_URL_PATH, SECURITY_TOKENS_PATH, timeToLive, false)
+    new AuthenticatorConfiguration(MAUTH_BASE_URL, MAUTH_URL_PATH, SECURITY_TOKENS_PATH, false)
 
   it should "send correct request for public key to MAuth server" in {
     FakeMAuthServer.return200()

--- a/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/AuthenticatorConfiguration.java
+++ b/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/AuthenticatorConfiguration.java
@@ -7,13 +7,12 @@ public class AuthenticatorConfiguration implements MAuthConfiguration{
   public static final String BASE_URL_PATH = MAUTH_SECTION_HEADER + ".base_url";
   public static final String REQUEST_URL_PATH = MAUTH_SECTION_HEADER + ".request_url";
   public static final String TOKEN_URL_PATH = MAUTH_SECTION_HEADER + ".token_url";
-  public static final String TIME_TO_LIVE_SECONDS = MAUTH_SECTION_HEADER + ".cache.time_to_live_seconds";
   public static final String V2_ONLY_AUTHENTICATE= MAUTH_SECTION_HEADER + ".v2_only_authenticate";
+  private static final long CACHE_TIME_TO_LIVE_SECONDS = 300L;
 
   private final String baseUrl;
   private final String requestUrlPath;
   private final String securityTokensUrlPath;
-  private final Long timeToLive;
   private final boolean v2OnlyAuthenticate;
 
   public AuthenticatorConfiguration(Config config) {
@@ -21,28 +20,36 @@ public class AuthenticatorConfiguration implements MAuthConfiguration{
         config.getString(BASE_URL_PATH),
         config.getString(REQUEST_URL_PATH),
         config.getString(TOKEN_URL_PATH),
-        config.getLong(TIME_TO_LIVE_SECONDS),
         config.getBoolean(V2_ONLY_AUTHENTICATE)
     );
   }
 
-  public AuthenticatorConfiguration(String baseUrl, String requestUrlPath, String securityTokensUrlPath, Long timeToLive) {
-    this (baseUrl, requestUrlPath, securityTokensUrlPath, timeToLive, false);
+  public AuthenticatorConfiguration(String baseUrl, String requestUrlPath, String securityTokensUrlPath) {
+    this (baseUrl, requestUrlPath, securityTokensUrlPath, false);
   }
 
-  public AuthenticatorConfiguration(String baseUrl, String requestUrlPath, String securityTokensUrlPath, Long timeToLive, boolean v2OnlyAuthenticate) {
+  public AuthenticatorConfiguration(String baseUrl, String requestUrlPath, String securityTokensUrlPath, boolean v2OnlyAuthenticate) {
     validateNotBlank(baseUrl, "MAuth base url");
     validateNotBlank(requestUrlPath, "MAuth request url path");
     validateNotBlank(securityTokensUrlPath, "MAuth Security tokens url path");
     this.baseUrl = baseUrl;
     this.requestUrlPath = requestUrlPath;
     this.securityTokensUrlPath = securityTokensUrlPath;
-    this.timeToLive = timeToLive;
     this.v2OnlyAuthenticate = v2OnlyAuthenticate;
   }
 
+  @Deprecated
+  public AuthenticatorConfiguration(String baseUrl, String requestUrlPath, String securityTokensUrlPath, Long timeToLive) {
+    this (baseUrl, requestUrlPath, securityTokensUrlPath, false);
+  }
+
+  @Deprecated
+  public AuthenticatorConfiguration(String baseUrl, String requestUrlPath, String securityTokensUrlPath, Long timeToLive, boolean v2OnlyAuthenticate) {
+    this (baseUrl, requestUrlPath, securityTokensUrlPath, v2OnlyAuthenticate);
+  }
+
   public long getTimeToLive() {
-    return timeToLive;
+    return CACHE_TIME_TO_LIVE_SECONDS;
   }
 
   public String getRequestUrlPath() {

--- a/modules/mauth-authenticator/src/main/resources/reference.conf
+++ b/modules/mauth-authenticator/src/main/resources/reference.conf
@@ -2,8 +2,5 @@ mauth {
   base_url: ${?MAUTH_URL}
   request_url: "/mauth/v1"
   token_url: "/security_tokens/%s.json"
-  cache {
-    time_to_live_seconds: 90
-  }
   v2_only_authenticate: false
 }


### PR DESCRIPTION
This PR sets the fallback cache TTL to 5 minutes if Cache-Control is missing or malformed, see [MCC-805832)](https://jira.mdsol.com/browse/MCC-805832)

@jatcwang @austek @mdsol/architecture-enablement 