### PR TITLE
[MCC-880023] bump jackson-databind in mauth-proxy 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,27 @@
+dist: bionic
 language: java
-jdk:
-- oraclejdk8
+
+cache:
+  directories:
+  - "$HOME/.m2"
+
 env:
   global:
   - APP_UUID=398ea708-50eb-499f-98d3-14cc7692668c
-  - secure: n++Arc8CcxaAG17/0hXWM43QuAqFOyM83o1OuFh5hAz7nMeearWUTM7o/LaOw1tD0bqWoOEwZbiZ1T1PBPo8ItQmn7FYdo9yEpdf2/eJPGxViYagpBYEU8UZDwv9tQvUq3gYB1Jly60LhsuG/n/3cpclMHpGlBI11Q/Qm3pN66o=
-  - secure: OK5crzS2IVb0urPleQLXomHYKYBEcF2XJSHJ1zqGc8ibqt/YSMSIf4Huc9r89s6IIrjLhNv9HkyqNrxWcAKAvGinobOvVoSMB1DojH3k6CG8hpWLusjDty3RwjDYUrvYS39MGaHsGuIDnH7fXEKo7DvGl2/7KmkPcgE6NDh1xNo=
-cache:
-  directories:
-  - $HOME/.m2
-before_install:
- - export APP_PRIVATE_KEY=$(cat travis/fake_private_key_for_testing)
-install: mvn install -Dmaven.javadoc.skip=true -B -V --settings travis/settings.xml
-script: mvn test --settings travis/settings.xml
 
-deploy:
-  provider: script
-  script: mvn deploy -DskipTests=true --settings travis/settings.xml
-  on:
-    branch: develop
+matrix:
+  include:
+  - stage: Test
+    jdk: openjdk8
+    before_install: export APP_PRIVATE_KEY=$(cat travis/fake_private_key_for_testing)
+    install: mvn clean install -Dmaven.javadoc.skip=true -B -V --settings travis/settings.xml
+    script: skip
+  - stage: Publish
+    jdk: openjdk8
+    install: skip
+    script: skip
+    deploy:
+    - provider: script
+      script: "./travis/deploy.sh"
+      on:
+        tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [1.0.0.1]
+### Changed
+- bump the version of jackson-databind to 2.13.0.

--- a/mauth-authenticator-apachehttp/pom.xml
+++ b/mauth-authenticator-apachehttp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mauth-authenticator/pom.xml
+++ b/mauth-authenticator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mauth-common/pom.xml
+++ b/mauth-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mauth-proxy/pom.xml
+++ b/mauth-proxy/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mauth-proxy</artifactId>

--- a/mauth-signer-apachehttp/pom.xml
+++ b/mauth-signer-apachehttp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mauth-signer/pom.xml
+++ b/mauth-signer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mauth-test-utils/pom.xml
+++ b/mauth-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mauth-client</artifactId>
         <groupId>com.mdsol.clients</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,9 @@
 
     <repositories>
         <repository>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
             <id>central</id>
             <name>maven-prod-virtual</name>
             <url>https://mdsol.jfrog.io/artifactory/maven-prod-virtual/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mdsol.clients</groupId>
     <artifactId>mauth-client</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0.1</version>
     <packaging>pom</packaging>
 
     <name>mauth-client</name>
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.6.4</version>
+                <version>2.13.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -151,30 +151,19 @@
     <distributionManagement>
         <repository>
             <id>central</id>
-            <name>ctms-releases</name>
-            <url>https://artv4.imedidata.net/artifactory/ctms-releases/</url>
+            <name>platformLibraries-maven-prod-local</name>
+            <url>https://mdsol.jfrog.io/artifactory/PlatformLibraries-maven-prod-local/</url>
         </repository>
-        <snapshotRepository>
-            <id>snapshot</id>
-            <name>snapshot</name>
-            <url>https://artv4.imedidata.net/artifactory/ctms-snapshots/</url>
-        </snapshotRepository>
     </distributionManagement>
 
     <repositories>
         <repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
             <id>central</id>
-            <name>all-repos-release</name>
-            <url>https://artv4.imedidata.net/artifactory/all-repos-release</url>
-        </repository>
-        <repository>
-            <id>snapshot</id>
-            <name>snapshot</name>
-            <url>https://artv4.imedidata.net/artifactory/snapshot/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
+            <name>maven-prod-virtual</name>
+            <url>https://mdsol.jfrog.io/artifactory/maven-prod-virtual/</url>
         </repository>
     </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -148,14 +148,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>central</id>
-            <name>platformLibraries-maven-prod-local</name>
-            <url>https://mdsol.jfrog.io/artifactory/PlatformLibraries-maven-prod-local/</url>
-        </repository>
-    </distributionManagement>
-
     <repositories>
         <repository>
 			<snapshots>

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+release_repo_url="https://mdsol.jfrog.io/artifactory/PlatformLibraries-maven-prod-local"
+artifact_id=mauth-client
+group_id=com.mdsol.clients
+group_path=${group_id//.//} # com.mdsol.clients => com/mdsol/clients
+version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+module_name="the version $version of $artifact_id"
+
+release_status=$(curl -s -o /dev/null -w "%{http_code}" --head -u $ARTIFACTORY_ACCOUNT_NAME:$ARTIFACTORY_ACCESS_TOKEN \
+  "$release_repo_url/$group_path/$artifact_id/$version/")
+
+if [ $release_status -eq 200 ]; then
+  echo "Skipping deploy, $module_name already exists"
+else
+  echo "Deploying $module_name"
+  mvn clean deploy \
+    -Dmaven.javadoc.skip=true \
+    -Dmaven.test.skip=true \
+    -DaltDeploymentRepository=central::default::$release_repo_url \
+    -B -V \
+    --settings travis/settings.xml
+fi

--- a/travis/settings.xml
+++ b/travis/settings.xml
@@ -1,15 +1,12 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <servers>
-        <server>
-            <id>central</id>
-            <username>${env.REPO_USERNAME}</username>
-            <password>${env.REPO_PASSWORD}</password>
-        </server>
-        <server>
-            <id>snapshot</id>
-            <username>${env.REPO_USERNAME}</username>
-            <password>${env.REPO_PASSWORD}</password>
-        </server>
-    </servers>
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${ARTIFACTORY_ACCOUNT_NAME}</username>
+      <password>${ARTIFACTORY_ACCESS_TOKEN}</password>
+    </server>
+  </servers>
 </settings>


### PR DESCRIPTION
This PR includes the updates based on tag 1.0.0
- bump  jackson-databind to 2.13.0;
- bump the version of mauth-clients to 1.0.0.1;
- update the scripts of travis & deploy;

@mdsol/architecture-enablement 