### PR TITLE
NOJIRA fix body consumption in http4s

### DIFF
--- a/modules/mauth-authenticator-http4s/src/test/scala/com/mdsol/mauth/http4s/MAuthMiddlewareSuite.scala
+++ b/modules/mauth-authenticator-http4s/src/test/scala/com/mdsol/mauth/http4s/MAuthMiddlewareSuite.scala
@@ -14,6 +14,7 @@ import org.http4s._
 import org.http4s.{HttpRoutes, Request, Response}
 import org.http4s.syntax.literals._
 import org.http4s.Method._
+import org.typelevel.log4cats._
 
 import java.security.{PublicKey, Security}
 import java.util.UUID
@@ -22,7 +23,7 @@ import org.typelevel.log4cats.noop.NoOpLogger
 
 class MAuthMiddlewareSuite extends CatsEffectSuite {
 
-  implicit val logger = NoOpLogger[IO]
+  implicit val logger: Logger[IO] = NoOpLogger[IO]
   private val route: HttpRoutes[IO] =
     HttpRoutes.of {
       case req if req.uri.path === path"/" =>

--- a/modules/mauth-authenticator-http4s/src/test/scala/com/mdsol/mauth/http4s/MauthPublicKeyProviderSuite.scala
+++ b/modules/mauth-authenticator-http4s/src/test/scala/com/mdsol/mauth/http4s/MauthPublicKeyProviderSuite.scala
@@ -16,12 +16,13 @@ import scalacache.{Cache, Entry}
 
 import java.security.PublicKey
 import cats.implicits._
+import org.typelevel.log4cats.Logger
 
 import java.util.UUID
 
 class MauthPublicKeyProviderSuite extends CatsEffectSuite {
 
-  implicit val logger = NoOpLogger[IO]
+  implicit val logger: Logger[IO] = NoOpLogger[IO]
   private val MAUTH_PORT = PortFinder.findFreePort()
   private val MAUTH_BASE_URL = s"http://localhost:$MAUTH_PORT"
   private val MAUTH_URL_PATH = "/mauth/v1"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -6,7 +6,7 @@ import sbt._
 object BuildSettings {
   val env: util.Map[String, String] = System.getenv()
   val scala212 = "2.12.17"
-  val scala213 = "2.13.10"
+  val scala213 = "2.13.14"
 
   lazy val basicSettings = Seq(
     homepage := Some(new URL("https://github.com/mdsol/mauth-jvm-clients")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version = 1.8.3
+sbt.version =1.10.0


### PR DESCRIPTION
As reported on [this http4s issue](https://github.com/http4s/http4s/issues/7443), in some conditions, if the request's EntityBody is consumed more than once by the caller, a `BodyAlreadyConsumedError` is raised. In our MAuthMiddleware, this can happen when performing the mAuth authentication on large or slow requests, whereby the request's Stream might be chunked, requiring multiple consumptions and causing intermittent failures.

This PR aims at solving this bug