### PR TITLE
Publish mauth-test-utils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val `mauth-common` = javaModuleProject("mauth-common")
 
 lazy val `mauth-test-utils` = javaModuleProject("mauth-test-utils")
   .settings(
-    noPublishSettings,
+    publishSettings,
     libraryDependencies ++=
       Dependencies.compile(commonsIO, logbackClassic, wiremock).map(withExclusions)
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -67,10 +67,6 @@ object BuildSettings {
     }
   )
 
-  lazy val noPublishSettings = Seq(
-    publish / skip := true
-  )
-
   lazy val publishSettings = Seq(
     licenses := Seq("MDSOL" -> url("https://github.com/mdsol/mauth-jvm-clients/blob/master/LICENSE.txt")),
     scmInfo := Some(


### PR DESCRIPTION
After running into some maintenance issues with [clojure-mauth-client](https://github.com/mdsol/clojure-mauth-client), I would like to write a new version that reuses the production-proven Java core here, including the testing utilities. I first looked at adding it as a module here, with @tmilner's help, but we were not able to find a usable Clojure plugin for sbt.

This change simply publishes the mauth-test-utils module as an artifact, so that other JVM-based projects with different build tools can reuse it.

Other alternatives considered:

- Write the Clojure implementation without using mauth-test-utils. This would involve reinventing an excessive number of wheels.
- Migrate this project to gradle or maven, which are generally able to support any JVM language. This may be worth considering in the long term, but it would be a major undertaking.
- Add a second build process within this project, living alongside sbt. This would probably be unreasonably complex and confusing.